### PR TITLE
修复ISSUE #90 相关mcp失败问题

### DIFF
--- a/backend/api/mcp.py
+++ b/backend/api/mcp.py
@@ -217,7 +217,7 @@ async def test_server(data: Dict[str, Any]):
                 server_id = server_config.id or server_config.name or "unknown"
                 manager._server_configs[server_id] = server_config
 
-                if server_id in manager._stacks:
+                if server_id in manager._conn_tasks:
                     await manager.reconnect_server(server_id)
                 else:
                     import asyncio

--- a/backend/modules/channels/handler.py
+++ b/backend/modules/channels/handler.py
@@ -353,6 +353,18 @@ class ChannelMessageHandler:
         )
         self.agent_loop.tools = self.tool_registry
 
+    def _reconcile_mcp_tools(self) -> None:
+        """每轮消息前，把本 handler 的注册表与当前全局 MCP 工具集对齐。
+
+        与 WS 对话同理：本注册表在整个 handler 生命周期内复用，若不重新对齐，
+        中途改了 MCP 配置后老会话就加载不到最新工具。
+        """
+        try:
+            from backend.modules.mcp.client import McpClientManager
+            McpClientManager.get_instance().reconcile_registry_sync(self.tool_registry)
+        except Exception as exc:
+            logger.debug(f"MCP reconcile skipped: {exc}")
+
     # ------------------------------------------------------------------
     # 配置热重载
     # ------------------------------------------------------------------
@@ -605,6 +617,7 @@ class ChannelMessageHandler:
                 return
 
             self.tool_registry.set_session_id(session_id)
+            self._reconcile_mcp_tools()
             workflow_tool = self.tool_registry.get_tool("workflow_run")
             if workflow_tool and hasattr(workflow_tool, "set_event_callback"):
                 workflow_tool.set_event_callback(tool_event_handler)
@@ -1853,6 +1866,7 @@ class ChannelMessageHandler:
             self.tool_registry.set_session_id(session_id)
             self.tool_registry.set_channel(msg.channel)
             self.tool_registry.set_cancel_token(cancel_token)
+            self._reconcile_mcp_tools()
 
             await self._save_message(
                 session_id,

--- a/backend/modules/mcp/client.py
+++ b/backend/modules/mcp/client.py
@@ -503,7 +503,18 @@ class McpClientManager:
     _lock: asyncio.Lock = None  # 类级别锁，用于单例创建
 
     def __init__(self):
-        self._stacks: Dict[str, AsyncExitStack] = {}
+        # 每个 server 的“连接持有者任务”与其停止信号。
+        # 关键不变量：某条 stdio/sse/http 连接的 AsyncExitStack 必须在
+        # “进入它的那个任务”里退出（anyio cancel scope 要求），否则会抛
+        # RuntimeError: Attempted to exit cancel scope in a different task。
+        # 因此连接的 open/hold/close 全部锁死在 _run_server_connection 这一个任务内，
+        # 外部只通过 _stop_events 发信号、绝不跨任务 aclose()。
+        self._conn_tasks: Dict[str, asyncio.Task] = {}
+        self._stop_events: Dict[str, asyncio.Event] = {}
+        # 用户在运行时“显式停止”的 server：即便全局 MCP 开关仍开着，
+        # 也不应被 ensure_connected / reconnect_all 的惰性自动连接重新拉起，
+        # 否则“停止”会被下一次状态轮询立刻撤销（按钮停不下来）。
+        self._manually_stopped: set = set()
         self._connected = False
         self._connecting = False
         self._registry: Optional[ToolRegistry] = None
@@ -513,6 +524,8 @@ class McpClientManager:
         self._health_check_interval: int = 60
         self._max_reconnect_attempts: int = 3
         self._reconnect_backoff_base: float = 5.0
+        # 关闭单条连接时 aclose 的超时上限（秒），防止关闭卡死持有者任务
+        self._close_timeout: float = 10.0
         # Store tool wrappers for syncing to new registries
         self._tool_wrappers: Dict[str, Tool] = {}
         # 实例级别锁，用于保护并发操作
@@ -561,7 +574,7 @@ class McpClientManager:
             return False
         servers = [
             cfg for cfg in self._server_configs.values()
-            if cfg.enabled
+            if cfg.enabled and (cfg.id or cfg.name or "unknown") not in self._manually_stopped
         ]
         if not servers:
             return False
@@ -604,6 +617,47 @@ class McpClientManager:
             logger.debug(f"Synced {synced} MCP tools to new registry")
         return synced
 
+    def reconcile_registry_sync(self, registry: ToolRegistry) -> int:
+        """把某个会话级 registry 的 MCP 工具与“当前全局 MCP 工具集”全量对齐。
+
+        与 sync_to_registry_sync（只增不减）不同，这里做增/删/换：
+          - 新增：manager 有、registry 没有的工具
+          - 移除：registry 里以 mcp_ 开头、但 manager 当前已无的工具（配置删了/禁用了）
+          - 替换：wrapper 对象已更换（重连后指向新 session）的旧工具
+
+        用途：在每轮对话开始前调用，使“中途改了 MCP 配置”的老对话也能在下一条
+        消息加载到最新工具。同步、无 await、在事件循环上原子执行；幂等。
+
+        Returns 变更的工具数（新增 + 移除/替换）。
+        """
+        current = dict(self._tool_wrappers) if self._connected else {}
+        changed = 0
+
+        # 移除已不存在、或对象已变（重连）的旧 MCP 工具
+        for name in list(registry.list_tools()):
+            if not name.startswith("mcp_"):
+                continue
+            cur = current.get(name)
+            if cur is None or registry.get_tool(name) is not cur:
+                try:
+                    registry.unregister(name)
+                    changed += 1
+                except (KeyError, ValueError):
+                    pass
+
+        # 新增/补齐当前工具
+        for name, tool in current.items():
+            if not registry.has_tool(name):
+                try:
+                    registry.register(tool)
+                    changed += 1
+                except ValueError:
+                    pass
+
+        if changed:
+            logger.debug(f"Reconciled MCP tools into session registry: {changed} change(s)")
+        return changed
+
     async def sync_to_registry(self, registry: ToolRegistry) -> int:
         """Sync MCP tools to a new registry (e.g., per-WebSocket registry).
 
@@ -634,42 +688,24 @@ class McpClientManager:
                 logger.warning("McpClientManager: registry not set, cannot connect")
                 return
 
-            # Clear old wrappers before reconnecting
-            self._tool_wrappers.clear()
-
-            async def _connect_one(cfg: McpServerConfig):
-                server_id = cfg.id or cfg.name or "unknown"
-                try:
-                    stack = await connect_mcp_server(server_id, cfg, self._registry, out_wrappers=self._tool_wrappers)
-                    if stack:
-                        return server_id, stack
-                except Exception as exc:
-                    logger.error(f"MCP server '{server_id}' connection failed: {exc}")
-                return server_id, None
-
-            results = await asyncio.gather(
-                *[_connect_one(cfg) for cfg in enabled_servers],
-                return_exceptions=True,
-            )
-
-            for result in results:
-                if isinstance(result, Exception):
-                    logger.error(f"MCP connection error: {result}")
-                    continue
-                server_id, stack = result
-                if stack:
-                    self._stacks[server_id] = stack
-
             for cfg in enabled_servers:
                 server_id = cfg.id or cfg.name or "unknown"
                 self._server_configs[server_id] = cfg
 
-            self._mcp_tool_names = [
-                name for name in self._registry.list_tools() if name.startswith("mcp_")
-            ]
-            if self._stacks:
+            # 每个 server 各起一个“持有者任务”，并发等待各自“首次连接就绪”。
+            # 连接的 open/hold/close 全部发生在持有者任务内部（见 _run_server_connection），
+            # 这里只负责等待就绪结果，绝不持有或跨任务关闭连接。
+            await asyncio.gather(
+                *[
+                    self._start_connection(cfg.id or cfg.name or "unknown", cfg)
+                    for cfg in enabled_servers
+                ],
+                return_exceptions=True,
+            )
+
+            if self._conn_tasks:
                 self._connected = True
-                logger.info(f"MCP connected: {len(self._stacks)} servers, {len(self._mcp_tool_names)} tools")
+                logger.info(f"MCP connected: {len(self._conn_tasks)} servers, {len(self._mcp_tool_names)} tools")
                 self._start_health_check()
 
                 # 通知所有活跃的WebSocket会话MCP已连接
@@ -683,56 +719,150 @@ class McpClientManager:
         finally:
             self._connecting = False
 
+    # ---- 连接生命周期：open/hold/close 全部锁死在“持有者任务”内 -----------
+
+    async def _run_server_connection(
+        self, server_id: str, cfg: McpServerConfig, ready: asyncio.Future
+    ) -> None:
+        """单个 server 的连接持有者任务：在“本任务”内 open → hold → close。
+
+        - open ：connect_mcp_server 在本任务里 enter 传输的 AsyncExitStack
+        - hold ：await stop_event.wait()，挂起持有连接
+        - close：finally 里在“本任务”内关闭 stack —— 满足 anyio“同任务退出 cancel scope”的要求
+        ready 用于把“首次连接结果”回报给发起方（True/False）。
+        """
+        stop = asyncio.Event()
+        self._stop_events[server_id] = stop
+        stack: Optional[AsyncExitStack] = None
+        registered: List[str] = []
+        try:
+            stack = await connect_mcp_server(
+                server_id, cfg, self._registry, out_wrappers=self._tool_wrappers
+            )
+            if stack is None:
+                if not ready.done():
+                    ready.set_result(False)
+                return
+            registered = [
+                n for n in self._registry.list_tools()
+                if n.startswith(f"mcp_{server_id}_")
+            ]
+            for n in registered:
+                if n not in self._mcp_tool_names:
+                    self._mcp_tool_names.append(n)
+            logger.info(f"MCP server '{server_id}': connected, holding {len(registered)} tools")
+            if not ready.done():
+                ready.set_result(True)
+            await stop.wait()  # 持有连接，直到被要求停止（stop.set）或被取消
+        except asyncio.CancelledError:
+            logger.info(f"MCP server '{server_id}': connection task cancelled")
+            raise
+        except Exception as exc:
+            logger.error(f"MCP server '{server_id}': connection error: {type(exc).__name__}: {exc}")
+            if not ready.done():
+                ready.set_result(False)
+        finally:
+            # 关键：正常停止或被取消，都在“本任务”内关闭 stack。
+            # 被取消时 stack.aclose() 让 anyio 在同任务解开 cancel scope 并终止子进程（B 兜底强杀）。
+            if stack is not None:
+                await self._safe_aclose(stack, server_id)
+            self._unregister_names(registered)
+            self._stop_events.pop(server_id, None)
+            # 仅当登记的仍是“自己”这个任务时才移除，避免误删重连后新建的任务
+            if self._conn_tasks.get(server_id) is asyncio.current_task():
+                self._conn_tasks.pop(server_id, None)
+
+    async def _safe_aclose(self, stack: AsyncExitStack, server_id: str) -> None:
+        """在本任务内关闭 stack；带超时与兜底，绝不卡死持有者任务或向外抛出。"""
+        try:
+            await asyncio.wait_for(stack.aclose(), timeout=self._close_timeout)
+        except asyncio.TimeoutError:
+            logger.warning(f"MCP server '{server_id}': aclose timed out after {self._close_timeout}s")
+        except (RuntimeError, BaseExceptionGroup) as exc:
+            # 同任务关闭理论上不再出现 cancel-scope 错误；保留为兜底日志
+            logger.warning(f"MCP server '{server_id}': aclose raised {type(exc).__name__}: {exc}")
+        except Exception as exc:
+            logger.warning(f"MCP server '{server_id}': aclose unexpected error: {exc}")
+
+    def _unregister_names(self, names: List[str]) -> None:
+        for n in names:
+            try:
+                self._registry.unregister(n)
+            except (KeyError, ValueError):
+                pass
+            if n in self._mcp_tool_names:
+                self._mcp_tool_names.remove(n)
+            self._tool_wrappers.pop(n, None)
+
+    async def _start_connection(self, server_id: str, cfg: McpServerConfig) -> bool:
+        """（重新）建立某 server 的连接：先停旧持有者任务，再起新任务并等待就绪。"""
+        if self._registry is None:
+            logger.warning(f"MCP server '{server_id}': registry not set, cannot connect")
+            return False
+        # 显式连接即“希望它运行”，撤销之前的手动停止标记
+        self._manually_stopped.discard(server_id)
+        if server_id in self._conn_tasks:
+            await self._stop_connection(server_id)
+        ready: asyncio.Future = asyncio.get_event_loop().create_future()
+        task = asyncio.create_task(self._run_server_connection(server_id, cfg, ready))
+        self._conn_tasks[server_id] = task
+        try:
+            return bool(await ready)
+        except Exception:
+            return False
+
+    async def _stop_connection(self, server_id: str, timeout: float = 5.0) -> None:
+        """停止某 server 的持有者任务：先发 stop 信号优雅退出；超时则强制取消。
+
+        取消会让持有者任务在“本任务”内解开 AsyncExitStack，
+        anyio 借此终止子进程 —— 即所选方案的“B 兜底：强杀”。
+        """
+        stop = self._stop_events.get(server_id)
+        task = self._conn_tasks.get(server_id)
+        if stop is not None:
+            stop.set()
+        if task is not None and not task.done():
+            done, _ = await asyncio.wait({task}, timeout=timeout)
+            if task not in done:
+                logger.warning(f"MCP server '{server_id}': graceful stop timed out, cancelling owner task")
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    pass
+        self._conn_tasks.pop(server_id, None)
+        self._stop_events.pop(server_id, None)
+
     async def reconnect_server(self, server_id: str) -> bool:
-        """重连指定服务器（线程安全）"""
+        """重连指定服务器（线程安全）。"""
         async with self._operation_lock:
             if server_id not in self._server_configs:
                 logger.warning(f"MCP server '{server_id}': no config found for reconnect")
                 return False
-
             cfg = self._server_configs[server_id]
 
-            old_stack = self._stacks.pop(server_id, None)
-        if old_stack:
-            try:
-                await old_stack.aclose()
-            except (RuntimeError, BaseExceptionGroup):
-                pass
+        for attempt in range(1, self._max_reconnect_attempts + 1):
+            if attempt > 1:
+                delay = self._reconnect_backoff_base * (2 ** (attempt - 2))
+                logger.info(f"MCP server '{server_id}': reconnect attempt {attempt}/{self._max_reconnect_attempts} in {delay:.0f}s")
+                await asyncio.sleep(delay)
+            if await self._start_connection(server_id, cfg):
+                logger.info(f"MCP server '{server_id}': reconnected successfully")
+                return True
 
-        tools_to_remove = [n for n in self._mcp_tool_names if n.startswith(f"mcp_{server_id}_")]
-        for name in tools_to_remove:
-            try:
-                self._registry.unregister(name)
-            except (KeyError, ValueError):
-                pass
-            self._mcp_tool_names.remove(name)
-            self._tool_wrappers.pop(name, None)
-
-            for attempt in range(1, self._max_reconnect_attempts + 1):
-                delay = self._reconnect_backoff_base * (2 ** (attempt - 1))
-                if attempt > 1:
-                    logger.info(f"MCP server '{server_id}': reconnect attempt {attempt}/{self._max_reconnect_attempts} in {delay:.0f}s")
-                    await asyncio.sleep(delay)
-
-                try:
-                    stack = await connect_mcp_server(server_id, cfg, self._registry, out_wrappers=self._tool_wrappers)
-                    if stack:
-                        self._stacks[server_id] = stack
-                        new_tools = [n for n in self._registry.list_tools() if n.startswith(f"mcp_{server_id}_") and n not in self._mcp_tool_names]
-                        self._mcp_tool_names.extend(new_tools)
-                        logger.info(f"MCP server '{server_id}': reconnected successfully, {len(new_tools)} tools")
-                        return True
-                except Exception as exc:
-                    logger.error(f"MCP server '{server_id}': reconnect attempt {attempt} failed: {exc}")
-
-            logger.error(f"MCP server '{server_id}': all {self._max_reconnect_attempts} reconnect attempts failed")
-            return False
+        logger.error(f"MCP server '{server_id}': all {self._max_reconnect_attempts} reconnect attempts failed")
+        return False
 
     async def reconnect_all(self) -> None:
         if not self._server_configs:
             logger.warning("MCP: no server configs available for reconnect")
             return
-        failed_servers = [sid for sid in self._server_configs if sid not in self._stacks]
+        failed_servers = [
+            sid for sid in self._server_configs
+            if sid not in self._conn_tasks and sid not in self._manually_stopped
+        ]
         if not failed_servers:
             logger.info("MCP: all servers are connected, nothing to reconnect")
             return
@@ -746,12 +876,16 @@ class McpClientManager:
         self._reconnect_task = asyncio.create_task(self._health_check_loop())
 
     async def _health_check_loop(self) -> None:
-        while self._connected and self._stacks:
+        while self._connected and self._conn_tasks:
             await asyncio.sleep(self._health_check_interval)
             if not self._connected:
                 break
             dead_servers: List[str] = []
-            for server_id, stack in list(self._stacks.items()):
+            for server_id in list(self._conn_tasks.keys()):
+                task = self._conn_tasks.get(server_id)
+                if task is None or task.done():
+                    dead_servers.append(server_id)
+                    continue
                 try:
                     for name in self._mcp_tool_names:
                         if name.startswith(f"mcp_{server_id}_"):
@@ -768,33 +902,19 @@ class McpClientManager:
 
             for server_id in dead_servers:
                 logger.warning(f"MCP server '{server_id}': connection lost, scheduling reconnect")
-                self._stacks.pop(server_id, None)
                 asyncio.create_task(self.reconnect_server(server_id))
 
-            if not self._stacks and self._connected:
+            if not self._conn_tasks and self._connected:
                 self._connected = False
                 logger.warning("MCP: all servers disconnected")
 
     async def disconnect_server(self, server_id: str) -> bool:
-        """断开指定服务器（线程安全）"""
+        """断开指定服务器（线程安全）。"""
         async with self._operation_lock:
-            stack = self._stacks.pop(server_id, None)
-        if stack:
-            try:
-                await stack.aclose()
-            except (RuntimeError, BaseExceptionGroup):
-                logger.debug(f"MCP server '{server_id}' cleanup error (can be ignored)")
-
-        tools_to_remove = [n for n in self._mcp_tool_names if n.startswith(f"mcp_{server_id}_")]
-        for name in tools_to_remove:
-            try:
-                self._registry.unregister(name)
-            except (KeyError, ValueError):
-                pass
-            self._mcp_tool_names.remove(name)
-            self._tool_wrappers.pop(name, None)
-
-            if not self._stacks and self._connected:
+            # 标记为“用户手动停止”，避免被惰性自动连接立刻拉起
+            self._manually_stopped.add(server_id)
+            await self._stop_connection(server_id)
+            if not self._conn_tasks and self._connected:
                 self._connected = False
                 if self._reconnect_task and not self._reconnect_task.done():
                     self._reconnect_task.cancel()
@@ -804,13 +924,13 @@ class McpClientManager:
                         pass
                     self._reconnect_task = None
 
-            logger.info(f"MCP server '{server_id}' disconnected")
-            return True
+        logger.info(f"MCP server '{server_id}' disconnected")
+        return True
 
     async def start_server(self, server_id: str) -> bool:
-        """启动指定服务器（线程安全）"""
+        """启动指定服务器（线程安全）。"""
         async with self._operation_lock:
-            if server_id in self._stacks:
+            if server_id in self._conn_tasks:
                 logger.warning(f"MCP server '{server_id}' is already running")
                 return True
             if server_id not in self._server_configs:
@@ -818,18 +938,13 @@ class McpClientManager:
                 return False
             cfg = self._server_configs[server_id]
 
-        try:
-            stack = await connect_mcp_server(server_id, cfg, self._registry, out_wrappers=self._tool_wrappers)
-            if stack:
-                async with self._operation_lock:
-                    self._stacks[server_id] = stack
-                    new_tools = [n for n in self._registry.list_tools() if n.startswith(f"mcp_{server_id}_") and n not in self._mcp_tool_names]
-                    self._mcp_tool_names.extend(new_tools)
-                    self._connected = True
-                logger.info(f"MCP server '{server_id}': started successfully, {len(new_tools)} tools")
-                return True
-        except Exception as exc:
-            logger.error(f"MCP server '{server_id}': start failed: {exc}")
+        if await self._start_connection(server_id, cfg):
+            async with self._operation_lock:
+                self._connected = True
+            logger.info(f"MCP server '{server_id}': started successfully")
+            return True
+
+        logger.error(f"MCP server '{server_id}': start failed")
         return False
 
     async def disconnect(self) -> None:
@@ -843,16 +958,19 @@ class McpClientManager:
                     pass
                 self._reconnect_task = None
 
-            self._unregister_mcp_tools()
+            # 逐个停止持有者任务（每个任务在自己上下文里关闭连接）
+            for server_id in list(self._conn_tasks.keys()):
+                await self._stop_connection(server_id)
 
-            for name, stack in self._stacks.items():
-                try:
-                    await stack.aclose()
-                except (RuntimeError, BaseExceptionGroup):
-                    logger.debug(f"MCP server '{name}' cleanup error (can be ignored)")
-            self._stacks.clear()
+            # 兜底清理注册表残留
+            self._unregister_mcp_tools()
             self._server_configs.clear()
             self._tool_wrappers.clear()
+            self._mcp_tool_names.clear()
+            # 全局断开是一次整体重置：清空“手动停止”标记，
+            # 下次全局启用时所有 enabled server 都应能正常拉起。
+            self._manually_stopped.clear()
+            self._connected = False
             self._connecting = False
             logger.info("MCP disconnected")
 
@@ -867,13 +985,13 @@ class McpClientManager:
         server_status = {}
         for server_id, cfg in self._server_configs.items():
             server_status[server_id] = {
-                "connected": server_id in self._stacks,
+                "connected": server_id in self._conn_tasks,
                 "transport": cfg.transport or "auto",
                 "tool_count": len([n for n in self._mcp_tool_names if n.startswith(f"mcp_{server_id}_")]),
             }
         return {
             "connected": self._connected,
-            "servers": list(self._stacks.keys()),
+            "servers": list(self._conn_tasks.keys()),
             "all_configured": list(self._server_configs.keys()),
             "server_status": server_status,
             "tool_count": len(self._mcp_tool_names),

--- a/backend/modules/mcp/service.py
+++ b/backend/modules/mcp/service.py
@@ -93,7 +93,7 @@ class McpService:
             return {
                 "status": "connected",
                 "server_count": len(servers),
-                "connected_servers": list(self._manager._stacks.keys())
+                "connected_servers": list(self._manager._conn_tasks.keys())
             }
 
     async def disconnect_all(self) -> None:

--- a/backend/ws/events.py
+++ b/backend/ws/events.py
@@ -297,6 +297,15 @@ async def handle_message_event(
             agent_loop.tools.set_session_id(session_id)
             agent_loop.tools.set_cancel_token(cancel_token)
             logger.debug(f"Propagated session_id={session_id} to tool registry")
+
+            # 每轮对话开始前，把会话级注册表的 MCP 工具与当前全局 MCP 工具集对齐。
+            # 修复“中途改了 MCP 配置，老对话不加载新工具”的问题：本连接的注册表只在
+            # WS 建立时同步过一次，这里让它在每条消息前重新对齐（增/删/换）。
+            try:
+                from backend.modules.mcp.client import McpClientManager
+                McpClientManager.get_instance().reconcile_registry_sync(agent_loop.tools)
+            except Exception as e:
+                logger.debug(f"MCP reconcile skipped: {e}")
         explicit_external_request = _resolve_explicit_external_tool_request(
             agent_loop,
             content,

--- a/tests/test_mcp_reconcile.py
+++ b/tests/test_mcp_reconcile.py
@@ -1,0 +1,121 @@
+"""reconcile_registry_sync 回归测试。
+
+场景：MCP 配置中途变化后，长生命周期的会话级注册表能否被“全量对齐”
+（增/删/换），从而修复“老对话不加载新工具”。
+"""
+
+import sys
+import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from backend.modules.mcp.client import McpClientManager
+from backend.modules.tools.registry import ToolRegistry
+from backend.modules.tools.base import Tool
+
+
+class DummyTool(Tool):
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def description(self):
+        return self._name
+
+    @property
+    def parameters(self):
+        return {"type": "object", "properties": {}}
+
+    async def execute(self, **kwargs):
+        return self._name
+
+
+def _mgr_with(wrappers):
+    mgr = McpClientManager()
+    mgr._connected = True
+    mgr._tool_wrappers = dict(wrappers)
+    return mgr
+
+
+def test_reconcile_adds_new_tools():
+    """老对话注册表里没有的新 MCP 工具，应被补齐。"""
+    reg = ToolRegistry()
+    reg.register(DummyTool("shell"))  # 非 MCP 本地工具
+    a, b = DummyTool("mcp_demo_add"), DummyTool("mcp_demo_echo")
+    mgr = _mgr_with({"mcp_demo_add": a, "mcp_demo_echo": b})
+
+    changed = mgr.reconcile_registry_sync(reg)
+
+    assert changed == 2
+    assert reg.has_tool("mcp_demo_add") and reg.has_tool("mcp_demo_echo")
+    assert reg.has_tool("shell"), "本地工具不受影响"
+
+
+def test_reconcile_removes_deleted_tools():
+    """配置里删掉的 MCP 工具，应从注册表移除；本地工具保留。"""
+    reg = ToolRegistry()
+    reg.register(DummyTool("shell"))
+    reg.register(DummyTool("mcp_demo_add"))
+    reg.register(DummyTool("mcp_old_gone"))  # manager 已无
+    keep = DummyTool("mcp_demo_add")
+    mgr = _mgr_with({"mcp_demo_add": keep})
+
+    changed = mgr.reconcile_registry_sync(reg)
+
+    # mcp_old_gone 被移除(1)，mcp_demo_add 对象不同被替换(移除+新增=2)
+    assert not reg.has_tool("mcp_old_gone")
+    assert reg.has_tool("mcp_demo_add")
+    assert reg.get_tool("mcp_demo_add") is keep, "应替换为 manager 当前的 wrapper"
+    assert reg.has_tool("shell")
+    assert changed == 3
+
+
+def test_reconcile_replaces_reconnected_wrapper():
+    """重连后 wrapper 对象更换：注册表里的旧对象应被替换为新对象。"""
+    reg = ToolRegistry()
+    old = DummyTool("mcp_demo_add")
+    reg.register(old)
+    new = DummyTool("mcp_demo_add")
+    mgr = _mgr_with({"mcp_demo_add": new})
+
+    mgr.reconcile_registry_sync(reg)
+
+    assert reg.get_tool("mcp_demo_add") is new
+    assert reg.get_tool("mcp_demo_add") is not old
+
+
+def test_reconcile_when_disconnected_removes_all_mcp():
+    """MCP 未连接：注册表里的 MCP 工具应全部移除，本地工具保留。"""
+    reg = ToolRegistry()
+    reg.register(DummyTool("shell"))
+    reg.register(DummyTool("mcp_demo_add"))
+    mgr = McpClientManager()
+    mgr._connected = False
+    mgr._tool_wrappers = {}
+
+    changed = mgr.reconcile_registry_sync(reg)
+
+    assert not reg.has_tool("mcp_demo_add")
+    assert reg.has_tool("shell")
+    assert changed == 1
+
+
+def test_reconcile_idempotent():
+    """已对齐时再次调用不产生变更。"""
+    reg = ToolRegistry()
+    a = DummyTool("mcp_demo_add")
+    mgr = _mgr_with({"mcp_demo_add": a})
+
+    assert mgr.reconcile_registry_sync(reg) == 1
+    assert mgr.reconcile_registry_sync(reg) == 0
+    assert mgr.reconcile_registry_sync(reg) == 0
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_mcp_reconnect.py
+++ b/tests/test_mcp_reconnect.py
@@ -1,0 +1,304 @@
+"""McpClientManager 连接生命周期回归测试（持有者任务模型）。
+
+背景：MCP 的 stdio/sse/http 传输由 anyio 实现，其 cancel scope 必须在
+“进入它的那个任务”里退出。历史实现把连接的 open 放在临时任务（connect 的
+gather 子任务）里、close 却在别的任务里做，触发
+    RuntimeError: Attempted to exit cancel scope in a different task
+导致“测试连接成功、但持久连接 0 tools / 启动失败 / 子进程泄漏”。
+
+修复后：每个 server 由一个“持有者任务”独占——open/hold/close 全在同一任务内，
+外部只通过 stop 信号或取消来停止。本文件用替身验证该模型的逻辑正确性；
+真正的“跨任务不再抛 RuntimeError”由 mcp_demo_server/run_e2e.py 端到端验证。
+
+无第三方 async 插件：用 asyncio.run 驱动。
+"""
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import backend.modules.mcp.client as mcp_client
+from backend.modules.mcp.client import McpClientManager
+
+
+class FakeRegistry:
+    """实现持有者任务用到的 registry 接口。"""
+
+    def __init__(self):
+        self._tools = {}  # 健康检查会读 _tools
+
+    def register_name(self, name):
+        self._tools[name] = types.SimpleNamespace(name=name)
+
+    def unregister(self, name):
+        if name in self._tools:
+            del self._tools[name]
+            return True
+        raise KeyError(name)
+
+    def list_tools(self):
+        return sorted(self._tools)
+
+
+class FakeStack:
+    def __init__(self):
+        self.closed = False
+
+    async def aclose(self):
+        self.closed = True
+
+
+def _cfg(server_id):
+    return types.SimpleNamespace(
+        id=server_id, name=server_id, enabled=True,
+        connect_timeout=10, timeout=30, transport="stdio",
+    )
+
+
+def _make_manager(server_id):
+    mgr = McpClientManager()
+    mgr.set_registry(FakeRegistry())
+    mgr._server_configs[server_id] = _cfg(server_id)
+    mgr._reconnect_backoff_base = 0.0  # 失败重试不真正 sleep
+    return mgr
+
+
+def _patch_connect(monkeypatch, tools, stacks=None):
+    """把 connect_mcp_server 换成受控替身：注册工具、返回可关闭的 FakeStack。
+
+    tools=None 表示模拟连接失败（返回 None）。
+    """
+    calls = {"count": 0}
+
+    async def fake_connect(server_id, cfg, registry, out_wrappers=None):
+        calls["count"] += 1
+        if tools is None:
+            return None
+        for suffix in tools:
+            name = f"mcp_{server_id}_{suffix}"
+            registry.register_name(name)
+            if out_wrappers is not None:
+                out_wrappers[name] = object()
+        st = FakeStack()
+        if stacks is not None:
+            stacks.append(st)
+        return st
+
+    monkeypatch.setattr(mcp_client, "connect_mcp_server", fake_connect)
+    return calls
+
+
+# --------------------------------------------------------------------------
+# reconnect_server
+# --------------------------------------------------------------------------
+def test_reconnect_new_server_connects(monkeypatch):
+    """0 连接的新 server：reconnect 应起持有者任务、注册工具、返回 True。"""
+    async def scenario():
+        mgr = _make_manager("srv")
+        calls = _patch_connect(monkeypatch, tools=["a", "b", "c"])
+
+        ok = await mgr.reconnect_server("srv")
+
+        assert ok is True
+        assert calls["count"] == 1
+        assert "srv" in mgr._conn_tasks, "应有持有者任务在持有连接"
+        assert set(mgr._mcp_tool_names) == {"mcp_srv_a", "mcp_srv_b", "mcp_srv_c"}
+        # 持有者任务应仍在运行（挂在 stop.wait 上）
+        assert not mgr._conn_tasks["srv"].done()
+
+        await mgr.disconnect_server("srv")  # 清理
+
+    asyncio.run(scenario())
+
+
+def test_reconnect_replaces_old_connection_no_leak(monkeypatch):
+    """再次 reconnect：旧持有者任务被停止、旧 stack 被关闭，工具数保持一致、无泄漏。"""
+    async def scenario():
+        mgr = _make_manager("srv")
+        stacks = []
+        _patch_connect(monkeypatch, tools=["a", "b"], stacks=stacks)
+
+        assert await mgr.reconnect_server("srv") is True
+        first_task = mgr._conn_tasks["srv"]
+        assert len(stacks) == 1
+
+        assert await mgr.reconnect_server("srv") is True
+        # 旧任务已结束、旧 stack 已在“它自己任务里”关闭
+        assert first_task.done()
+        assert stacks[0].closed is True, "旧连接的 stack 应被关闭（无子进程泄漏）"
+        assert len(stacks) == 2
+        assert set(mgr._mcp_tool_names) == {"mcp_srv_a", "mcp_srv_b"}, "重连后工具集合一致、无重复/残留"
+
+        await mgr.disconnect_server("srv")
+
+    asyncio.run(scenario())
+
+
+def test_reconnect_returns_false_when_connect_fails(monkeypatch):
+    """连接持续失败：应耗尽重试并返回 False。"""
+    async def scenario():
+        mgr = _make_manager("srv")
+        mgr._max_reconnect_attempts = 3
+        calls = _patch_connect(monkeypatch, tools=None)
+
+        ok = await mgr.reconnect_server("srv")
+
+        assert ok is False
+        assert calls["count"] == 3
+        assert "srv" not in mgr._conn_tasks
+
+    asyncio.run(scenario())
+
+
+def test_reconnect_unknown_server_returns_false(monkeypatch):
+    async def scenario():
+        mgr = _make_manager("known")
+        calls = _patch_connect(monkeypatch, tools=["x"])
+        ok = await mgr.reconnect_server("nope")
+        assert ok is False
+        assert calls["count"] == 0
+
+    asyncio.run(scenario())
+
+
+# --------------------------------------------------------------------------
+# disconnect_server
+# --------------------------------------------------------------------------
+def test_disconnect_stops_task_and_clears_tools(monkeypatch):
+    """断开：停止持有者任务、关闭 stack、清空工具、_connected 归零、返回 True。"""
+    async def scenario():
+        mgr = _make_manager("srv")
+        stacks = []
+        _patch_connect(monkeypatch, tools=["a", "b"], stacks=stacks)
+
+        assert await mgr.start_server("srv") is True
+        assert mgr._connected is True
+        task = mgr._conn_tasks["srv"]
+
+        ok = await mgr.disconnect_server("srv")
+
+        assert ok is True
+        assert task.done(), "持有者任务应已停止"
+        assert stacks[0].closed is True, "stack 应被关闭"
+        assert "srv" not in mgr._conn_tasks
+        assert [n for n in mgr._mcp_tool_names] == []
+        assert mgr._connected is False
+
+    asyncio.run(scenario())
+
+
+def test_disconnect_one_of_many_keeps_connected(monkeypatch):
+    """还有其它 server 时，断开其中一个不应清零 _connected。"""
+    async def scenario():
+        mgr = McpClientManager()
+        mgr.set_registry(FakeRegistry())
+        mgr._server_configs["A"] = _cfg("A")
+        mgr._server_configs["B"] = _cfg("B")
+        _patch_connect(monkeypatch, tools=["t"])
+
+        assert await mgr.start_server("A") is True
+        assert await mgr.start_server("B") is True
+
+        assert await mgr.disconnect_server("A") is True
+        assert "A" not in mgr._conn_tasks
+        assert "B" in mgr._conn_tasks
+        assert mgr._connected is True
+
+        await mgr.disconnect_server("B")
+
+    asyncio.run(scenario())
+
+
+def test_disconnect_all_stops_everything(monkeypatch):
+    async def scenario():
+        mgr = McpClientManager()
+        mgr.set_registry(FakeRegistry())
+        mgr._server_configs["A"] = _cfg("A")
+        mgr._server_configs["B"] = _cfg("B")
+        stacks = []
+        _patch_connect(monkeypatch, tools=["t"], stacks=stacks)
+
+        await mgr.start_server("A")
+        await mgr.start_server("B")
+        assert len(mgr._conn_tasks) == 2
+
+        await mgr.disconnect()
+
+        assert mgr._conn_tasks == {}
+        assert mgr._connected is False
+        assert all(s.closed for s in stacks), "所有连接的 stack 都应关闭"
+        assert mgr._mcp_tool_names == []
+
+    asyncio.run(scenario())
+
+
+# --------------------------------------------------------------------------
+# connect / start_server / _safe_aclose
+# --------------------------------------------------------------------------
+def test_connect_sets_connected_and_starts_health_check(monkeypatch):
+    """connect() 多 server：置 _connected、登记全部工具、起健康检查任务。"""
+    async def scenario():
+        mgr = McpClientManager()
+        mgr.set_registry(FakeRegistry())
+        _patch_connect(monkeypatch, tools=["t"])
+
+        await mgr.connect([_cfg("A"), _cfg("B")])
+
+        assert mgr._connected is True
+        assert set(mgr._conn_tasks) == {"A", "B"}
+        assert set(mgr._mcp_tool_names) == {"mcp_A_t", "mcp_B_t"}
+        assert mgr._reconnect_task is not None and not mgr._reconnect_task.done(), "应启动健康检查任务"
+
+        await mgr.disconnect()
+        assert mgr._conn_tasks == {}
+        assert mgr._connected is False
+
+    asyncio.run(scenario())
+
+
+def test_start_server_already_running_returns_true(monkeypatch):
+    """已在运行的 server 再次 start：直接返回 True，不重复发起连接。"""
+    async def scenario():
+        mgr = _make_manager("srv")
+        calls = _patch_connect(monkeypatch, tools=["t"])
+
+        assert await mgr.start_server("srv") is True
+        assert calls["count"] == 1
+        assert await mgr.start_server("srv") is True
+        assert calls["count"] == 1, "已运行时不应重复连接"
+
+        await mgr.disconnect_server("srv")
+
+    asyncio.run(scenario())
+
+
+def test_safe_aclose_swallows_errors_and_timeout():
+    """_safe_aclose：aclose 抛错或卡死都不得外泄、不得卡死持有者任务（B 兜底鲁棒性）。"""
+    async def scenario():
+        mgr = McpClientManager()
+
+        class RaisingStack:
+            async def aclose(self):
+                raise RuntimeError("Attempted to exit cancel scope in a different task")
+
+        # 抛错被吞（若外泄则本行会抛，测试失败）
+        await mgr._safe_aclose(RaisingStack(), "x")
+
+        class HangingStack:
+            async def aclose(self):
+                await asyncio.Event().wait()  # 永不返回
+
+        mgr._close_timeout = 0.05
+        # 超时被吞、不卡死
+        await mgr._safe_aclose(HangingStack(), "y")
+
+    asyncio.run(scenario())
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_mcp_stop_persists.py
+++ b/tests/test_mcp_stop_persists.py
@@ -1,0 +1,152 @@
+"""回归：手动“停止”某个 MCP server 后，不应被惰性自动连接立刻拉起。
+
+现象：单 server 时，点“停止”→ _connected 变 False，但全局 MCP 开关仍开着，
+下一次 /overview 轮询里的 ensure_connected() 把它又连回来 → 按钮停不下来。
+"""
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import backend.modules.mcp.client as mcp_client
+from backend.modules.mcp.client import McpClientManager
+
+
+class FakeRegistry:
+    def __init__(self):
+        self._tools = {}
+
+    def register_name(self, name):
+        self._tools[name] = types.SimpleNamespace(name=name)
+
+    def unregister(self, name):
+        if name in self._tools:
+            del self._tools[name]
+            return True
+        raise KeyError(name)
+
+    def list_tools(self):
+        return sorted(self._tools)
+
+
+class FakeStack:
+    async def aclose(self):
+        pass
+
+
+def _cfg(sid):
+    return types.SimpleNamespace(
+        id=sid, name=sid, enabled=True, connect_timeout=10, timeout=30, transport="stdio",
+    )
+
+
+def _patch_connect(monkeypatch, tools=("t",)):
+    calls = {"count": 0, "servers": []}
+
+    async def fake_connect(server_id, cfg, registry, out_wrappers=None):
+        calls["count"] += 1
+        calls["servers"].append(server_id)
+        for suffix in tools:
+            registry.register_name(f"mcp_{server_id}_{suffix}")
+        return FakeStack()
+
+    monkeypatch.setattr(mcp_client, "connect_mcp_server", fake_connect)
+    return calls
+
+
+def _mgr(sid="srv"):
+    m = McpClientManager()
+    m.set_registry(FakeRegistry())
+    m._server_configs[sid] = _cfg(sid)
+    return m
+
+
+def test_disconnect_marks_manually_stopped(monkeypatch):
+    async def scenario():
+        m = _mgr()
+        _patch_connect(monkeypatch)
+        assert await m.start_server("srv") is True
+        assert m._connected is True
+
+        assert await m.disconnect_server("srv") is True
+        assert "srv" in m._manually_stopped
+        assert "srv" not in m._conn_tasks
+        assert m._connected is False
+
+    asyncio.run(scenario())
+
+
+def test_reconnect_all_skips_manually_stopped(monkeypatch):
+    async def scenario():
+        m = _mgr()
+        calls = _patch_connect(monkeypatch)
+        await m.start_server("srv")
+        await m.disconnect_server("srv")
+        before = calls["count"]
+
+        await m.reconnect_all()  # 惰性重连不应把手动停止的 server 拉起
+
+        assert calls["count"] == before, "手动停止的 server 不应被 reconnect_all 重连"
+        assert "srv" not in m._conn_tasks
+
+    asyncio.run(scenario())
+
+
+def test_ensure_connected_does_not_revive_manually_stopped(monkeypatch):
+    """核心回归：ensure_connected（/overview 轮询触发）不得复活手动停止的 server。"""
+    async def scenario():
+        m = _mgr()
+        _patch_connect(monkeypatch)
+        await m.start_server("srv")
+        await m.disconnect_server("srv")
+
+        # 模拟全局 MCP 开关仍打开
+        from backend.modules.config.loader import config_loader
+        monkeypatch.setattr(config_loader.config.mcp, "enabled", True, raising=False)
+
+        revived = await m.ensure_connected()
+
+        assert revived is False
+        assert "srv" not in m._conn_tasks, "停止的 server 不应被 ensure_connected 复活"
+        assert m._connected is False
+
+    asyncio.run(scenario())
+
+
+def test_start_clears_manually_stopped(monkeypatch):
+    async def scenario():
+        m = _mgr()
+        _patch_connect(monkeypatch)
+        await m.start_server("srv")
+        await m.disconnect_server("srv")
+        assert "srv" in m._manually_stopped
+
+        assert await m.start_server("srv") is True
+        assert "srv" not in m._manually_stopped, "显式启动应撤销手动停止标记"
+        assert "srv" in m._conn_tasks
+        assert m._connected is True
+
+    asyncio.run(scenario())
+
+
+def test_disconnect_all_clears_manually_stopped(monkeypatch):
+    async def scenario():
+        m = _mgr()
+        _patch_connect(monkeypatch)
+        await m.start_server("srv")
+        await m.disconnect_server("srv")
+        assert m._manually_stopped
+
+        await m.disconnect()  # 全局断开=整体重置
+        assert m._manually_stopped == set()
+
+    asyncio.run(scenario())
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## 变更说明
修复mcp相关问题，具体如下：

（1）测试连接成功并正确在测试结果显示出文字xxx工具、但持久连接却一直是 0 tools 。


mcp连接在 A 任务打开、B 任务关闭，违反 anyio 同任务约束。改为每个 server 由“持有者任务”独占 open/hold/close。 

根因为：MCP 的 `stdio_client`（anyio 实现）内部用 `create_task_group()` 开 cancel scope，**必须在“进入它的那个任务”里退出**。旧实现在 `connect()` 的 `asyncio.gather` 子任务里打开连接、却在 `reconnect_server`/`disconnect_server`/健康检查等**别的任务**里 `stack.aclose()`，触发：
````
RuntimeError: Attempted to exit cancel scope in a different task than it was entered in
````
该错误被 `except (RuntimeError, BaseExceptionGroup): pass` 吞掉 → 子进程未干净终止、连接状态被判失效。而 `test_mcp_server` 把 open+list+close 全放一个任务里，所以单独点击测试是可以正常查询到工具列表并回写的。
修改方案为：
让 open/close 在同一个任务，从根上满足 anyio 结构化并发约束；外部只通过 `stop_event`/`cancel` 发信号，永不跨任务关闭。


（2）中途改 MCP 配置，老对话不加载新工具，改为每轮对话前配置重新加载。

（3）停止按钮点击无效，马上就变成启动状态了。这个本质是由于没法区分手动停止、自动重连。新增运行时“手动停止”集合，并在各路径维护。

## 变更类型
- [ ] Bug 修复

## 相关 Issue
建议关闭 #(issue 90)，已通过单元测试，以及手动测试，验证可用。
<img width="1870" height="1042" alt="PixPin_2026-07-12_00-42-55" src="https://github.com/user-attachments/assets/9b5d2151-0311-4ad3-97ef-b5bcecc69555" />



## 测试
描述你如何测试这些变更：
- [ ✅️] 本地测试通过
- [ ✅️] 添加了新的测试用例
- [ ✅️] 所有现有测试通过

## 检查清单
- [ ✅️] 代码遵循项目的代码风格
- [ ✅️] 进行了自我代码审查
- [ ✅️] 添加了必要的注释，特别是在复杂的地方
- [ ✅️] 更新了相关文档
- [ ✅️] 没有产生新的警告
- [ ✅️] 添加了测试证明修复有效或功能正常工作
- [✅️ ] 新的和现有的单元测试都通过
