### PR TITLE
feat(image-analysis): add optional Atlas Cloud provider

### DIFF
--- a/workspace/skills/image-analysis/SKILL.md
+++ b/workspace/skills/image-analysis/SKILL.md
@@ -6,7 +6,7 @@ homepage: https://github.com/countbot-ai/CountBot
 
 # 图片分析与识别
 
-支持智谱 GLM-4V 和千问 Qwen-VL 两种视觉模型。
+支持智谱 GLM-4V、千问 Qwen-VL 和 Atlas Cloud 视觉模型。
 
 当用户发送图片或要求分析图片时，必须使用此技能，不要使用 PIL、pytesseract 等其他方法。
 
@@ -24,13 +24,25 @@ homepage: https://github.com/countbot-ai/CountBot
   "qwen": {
     "api_key": "your-qwen-api-key",
     "model": "qwen3-vl-plus"
+  },
+  "atlas": {
+    "api_key": "",
+    "model": "qwen/qwen3-vl-235b-a22b-thinking",
+    "base_url": "https://api.atlascloud.ai/v1/chat/completions"
   }
 }
+```
+
+Atlas Cloud 也可通过环境变量配置，避免把密钥写入文件：
+
+```bash
+export ATLASCLOUD_API_KEY="your-atlascloud-api-key"
 ```
 
 API Key 获取：
 - 智谱（免费）：https://open.bigmodel.cn/
 - 千问：https://help.aliyun.com/zh/model-studio/get-api-key
+- Atlas Cloud：https://www.atlascloud.ai/
 
 ## 命令行调用
 
@@ -46,6 +58,9 @@ python3 skills/image-analysis/scripts/vision.py analyze --image img1.jpg --image
 
 # 指定模型
 python3 skills/image-analysis/scripts/vision.py analyze --image image.jpg --prompt "描述图片" --model qwen
+
+# 使用 Atlas Cloud（仅图片输入）
+python3 skills/image-analysis/scripts/vision.py analyze --image image.jpg --prompt "描述图片" --model atlas
 
 # 开启思考模式（仅智谱，提升准确度）
 python3 skills/image-analysis/scripts/vision.py analyze --image image.jpg --prompt "详细分析" --thinking
@@ -79,6 +94,7 @@ python3 skills/image-analysis/scripts/vision.py analyze --image data/temp/images
 | 简单描述 | 任意 |
 | 复杂推理、物体定位 | 智谱 + `--thinking` |
 | 高精度识别、文档解析 | 千问 |
+| 可选 OpenAI 兼容视觉接口 | Atlas Cloud |
 | 成本敏感 | 智谱（免费） |
 
 ## 注意事项
@@ -86,4 +102,5 @@ python3 skills/image-analysis/scripts/vision.py analyze --image data/temp/images
 - 本地图片自动转 Base64，支持 jpg/png/gif/webp/bmp
 - 智谱图片限制 5MB，像素不超过 6000x6000
 - 千问不支持同时处理图片、视频和文件
+- Atlas Cloud 当前仅支持图片输入；本地图片会转换为 Base64 Data URL
 - 思考模式会增加响应时间但提升准确度

--- a/workspace/skills/image-analysis/scripts/config.json
+++ b/workspace/skills/image-analysis/scripts/config.json
@@ -10,5 +10,10 @@
     "model": "qwen3-omni-flash-2025-12-01",
     "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
     "region": "beijing"
+  },
+  "atlas": {
+    "api_key": "",
+    "model": "qwen/qwen3-vl-235b-a22b-thinking",
+    "base_url": "https://api.atlascloud.ai/v1/chat/completions"
   }
 }

--- a/workspace/skills/image-analysis/scripts/config.json.example
+++ b/workspace/skills/image-analysis/scripts/config.json.example
@@ -10,5 +10,10 @@
     "model": "qwen3-vl-plus",
     "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
     "region": "beijing"
+  },
+  "atlas": {
+    "api_key": "",
+    "model": "qwen/qwen3-vl-235b-a22b-thinking",
+    "base_url": "https://api.atlascloud.ai/v1/chat/completions"
   }
 }

--- a/workspace/skills/image-analysis/scripts/vision.py
+++ b/workspace/skills/image-analysis/scripts/vision.py
@@ -25,7 +25,7 @@ def main():
     analyze_parser.add_argument('--video', action='append', help='视频 URL（可多次指定）')
     analyze_parser.add_argument('--file', action='append', help='文件 URL（可多次指定）')
     analyze_parser.add_argument('--prompt', required=True, help='提示词')
-    analyze_parser.add_argument('--model', choices=['zhipu', 'qwen'], help='指定模型')
+    analyze_parser.add_argument('--model', choices=['zhipu', 'qwen', 'atlas'], help='指定模型')
     analyze_parser.add_argument('--thinking', action='store_true', help='开启思考模式（仅智谱支持）')
     analyze_parser.add_argument('--json', action='store_true', help='JSON 格式输出')
     analyze_parser.add_argument('--show-usage', action='store_true', help='显示 token 使用情况')

--- a/workspace/skills/image-analysis/scripts/vision_manager.py
+++ b/workspace/skills/image-analysis/scripts/vision_manager.py
@@ -206,6 +206,63 @@ class VisionManager:
         response.raise_for_status()
         
         return response.json()
+
+    def analyze_with_atlas(
+        self,
+        prompt: str,
+        images: Optional[List[str]] = None,
+        videos: Optional[List[str]] = None,
+        files: Optional[List[str]] = None,
+        stream: bool = False
+    ) -> Dict:
+        """Use an Atlas Cloud vision model to analyze images."""
+        atlas_config = self.config.get('atlas', {})
+        api_key = atlas_config.get('api_key') or os.getenv('ATLASCLOUD_API_KEY')
+        model = atlas_config.get('model', 'qwen/qwen3-vl-235b-a22b-thinking')
+        base_url = atlas_config.get('base_url', 'https://api.atlascloud.ai/v1/chat/completions')
+
+        if not api_key:
+            raise ValueError("Atlas Cloud API Key 未配置，请设置 ATLASCLOUD_API_KEY 或 atlas.api_key")
+
+        if videos or files:
+            raise ValueError("Atlas Cloud 视觉模型当前仅支持图片输入")
+
+        content = []
+        if images:
+            for image in images:
+                image_url = self._prepare_image_url(image)
+                content.append({
+                    "type": "image_url",
+                    "image_url": {"url": image_url}
+                })
+
+        content.append({
+            "type": "text",
+            "text": prompt
+        })
+
+        payload = {
+            "model": model,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": content
+                }
+            ]
+        }
+
+        if stream:
+            payload["stream"] = True
+
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json"
+        }
+
+        response = requests.post(base_url, headers=headers, json=payload, timeout=120)
+        response.raise_for_status()
+
+        return response.json()
     
     def analyze(
         self,
@@ -226,8 +283,12 @@ class VisionManager:
             if thinking:
                 print("警告：千问模型不支持思考模式，将忽略该参数")
             return self.analyze_with_qwen(prompt, images, videos, files, stream)
+        elif use_model == 'atlas':
+            if thinking:
+                print("警告：Atlas Cloud 模型不支持此处的思考模式开关，将忽略该参数")
+            return self.analyze_with_atlas(prompt, images, videos, files, stream)
         else:
-            raise ValueError(f"不支持的模型: {use_model}，请选择 'zhipu' 或 'qwen'")
+            raise ValueError(f"不支持的模型: {use_model}，请选择 'zhipu'、'qwen' 或 'atlas'")
     
     def format_result(self, result: Dict, show_usage: bool = False) -> str:
         """格式化输出结果"""

--- a/workspace/skills/image-analysis/tests/test_vision_manager.py
+++ b/workspace/skills/image-analysis/tests/test_vision_manager.py
@@ -1,0 +1,68 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from vision_manager import VisionManager  # noqa: E402
+
+
+class AtlasVisionTests(unittest.TestCase):
+    def setUp(self):
+        self.config = {
+            "atlas": {
+                "api_key": "",
+                "model": "qwen/qwen3-vl-235b-a22b-thinking",
+                "base_url": "https://api.atlascloud.ai/v1/chat/completions",
+            }
+        }
+
+    @patch("vision_manager.requests.post")
+    def test_atlas_uses_environment_key_and_openai_image_payload(self, post):
+        response = Mock()
+        response.json.return_value = {
+            "choices": [{"message": {"content": "A test image"}}]
+        }
+        post.return_value = response
+
+        with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}):
+            result = VisionManager(self.config).analyze(
+                prompt="Describe this image",
+                images=["https://example.com/image.png"],
+                model="atlas",
+            )
+
+        self.assertEqual(result["choices"][0]["message"]["content"], "A test image")
+        post.assert_called_once()
+        url = post.call_args.args[0]
+        kwargs = post.call_args.kwargs
+        self.assertEqual(url, "https://api.atlascloud.ai/v1/chat/completions")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer test-key")
+        self.assertEqual(kwargs["timeout"], 120)
+        self.assertEqual(
+            kwargs["json"]["messages"][0]["content"][0],
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/image.png"},
+            },
+        )
+
+    @patch("vision_manager.requests.post")
+    def test_atlas_rejects_video_input_before_request(self, post):
+        with patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}):
+            with self.assertRaisesRegex(ValueError, "仅支持图片输入"):
+                VisionManager(self.config).analyze(
+                    prompt="Describe this video",
+                    videos=["https://example.com/video.mp4"],
+                    model="atlas",
+                )
+
+        post.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `atlas` as an optional image-analysis provider while preserving the existing default provider
- use Atlas Cloud's OpenAI-compatible chat completions protocol with `ATLASCLOUD_API_KEY` or `atlas.api_key`
- reject unsupported video/file inputs before sending a request and document setup and CLI usage

## Validation

- `python3 -m unittest discover -s workspace/skills/image-analysis/tests -v` (2 tests passed)
- `python3 -m py_compile workspace/skills/image-analysis/scripts/vision.py workspace/skills/image-analysis/scripts/vision_manager.py`
- missing-key CLI check
- `git diff --check`
- live model catalog verified the text/image input modalities and `openai.chat.completions` protocol; one non-retried live submit returned HTTP 403 before producing a response, and no second POST was made

## Notes

The existing Zhipu/Qwen behavior and default provider remain unchanged.