### PR TITLE
[Feature] Wiki 块级问答增加评估路由与诚实拒答（CRAG 式）：知识库没有答案时不再硬答

### DIFF
--- a/backend/modules/rag/__init__.py
+++ b/backend/modules/rag/__init__.py
@@ -1,0 +1,11 @@
+"""RAG 增强模块
+
+M1（分块 + BM25 分块级召回）：
+- chunker.py: HeadingChunker，按 Markdown 标题切块
+- stores/bm25_store.py: 分块级 BM25 索引（复用 wiki 的 BM25Index）
+- service.py: RagService，挂在 WikiService 之上，增量同步
+
+回滚开关：环境变量 COUNTBOT_RAG_CHUNKS=1 启用；缺省关闭（零行为变化）。
+"""
+
+from .chunker import Chunk, HeadingChunker  # noqa: F401

--- a/backend/modules/rag/chunker.py
+++ b/backend/modules/rag/chunker.py
@@ -1,0 +1,227 @@
+"""HeadingChunker - 按 Markdown 标题切分文档为块
+
+设计目标（M1）：
+- 以"标题节"为自然边界，保持语义完整（不破坏代码块/表格）；
+- 超长节按段落二次切分（代码围栏视为不可分割单元）；
+- 每块携带 [slug#section] 溯源标识；
+- 零第三方依赖（纯标准库）。
+
+token 口径：est_tokens = chars / 1.5（CJK 近似），与 rag-bench 基线一致。
+"""
+
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
+
+
+@dataclass
+class Chunk:
+    """一个可检索的内容块"""
+
+    chunk_id: str          # 溯源标识: {slug}#{section-anchor}
+    slug: str              # 所属文档 slug
+    doc_title: str         # 所属文档标题
+    section: str           # 节标题（首个标题前的内容为 ""）
+    heading_path: str      # 层级路径，如 "安装 > Linux"
+    content: str           # 块正文（不含节标题行）
+    tags: List[str] = field(default_factory=list)
+    mtime: float = 0.0
+
+    @property
+    def est_tokens(self) -> int:
+        return int(len(self.content) / 1.5)
+
+    @property
+    def index_title(self) -> str:
+        """用于 BM25 标题加权（×3）的复合标题：文档标题 + 节路径"""
+        parts = [self.doc_title]
+        if self.heading_path:
+            parts.append(self.heading_path)
+        return " · ".join(p for p in parts if p)
+
+
+def _slugify_anchor(text: str) -> str:
+    """标题 -> 稳定的 anchor（保留 CJK 与字母数字）"""
+    anchor = re.sub(r"[^\w\u4e00-\u9fff]+", "-", text.strip().lower())
+    anchor = anchor.strip("-")
+    return anchor or "section"
+
+
+class HeadingChunker:
+    """按标题切块 + 超长节按段落二次切分
+
+    Args:
+        max_chars: 单块正文上限（字符）。默认 1200 ≈ 800 est tokens。
+        min_chars: 低于此长度的独立段落并入前块，避免碎片。
+        overlap_chars: 二次切分时块尾重叠量，保证跨块语义连续。
+    """
+
+    def __init__(self, max_chars: int = 1200, min_chars: int = 80, overlap_chars: int = 120):
+        self.max_chars = max_chars
+        self.min_chars = min_chars
+        self.overlap_chars = overlap_chars
+
+    # ---------- 主入口 ----------
+
+    def chunk(
+        self,
+        slug: str,
+        title: str,
+        content: str,
+        tags: Optional[List[str]] = None,
+        mtime: float = 0.0,
+    ) -> List[Chunk]:
+        sections = self._split_by_headings(content)
+        chunks: List[Chunk] = []
+        anchor_counts = {}  # anchor 去重
+
+        for section, text in sections:
+            pieces = self._split_long_section(text)
+            for i, piece in enumerate(pieces):
+                anchor = _slugify_anchor(section) if section else "intro"
+                anchor_counts[anchor] = anchor_counts.get(anchor, 0) + 1
+                n = anchor_counts[anchor]
+                chunk_id = f"{slug}#{anchor}" if n == 1 else f"{slug}#{anchor}-{n}"
+                chunks.append(Chunk(
+                    chunk_id=chunk_id,
+                    slug=slug,
+                    doc_title=title,
+                    section=section or "概述",
+                    heading_path=section or "",
+                    content=piece,
+                    tags=list(tags or []),
+                    mtime=mtime,
+                ))
+        return chunks
+
+    # ---------- 一级切分：按标题 ----------
+
+    def _split_by_headings(self, content: str) -> List[tuple]:
+        """返回 [(节标题路径, 节正文), ...]
+
+        节标题路径 = 父级标题链，如 "部署 > Docker"。
+        标题本身保留在正文开头（索引时可加权，注入时提供上下文）。
+        """
+        lines = (content or "").splitlines()
+        sections: List[tuple] = []
+        heading_stack: List[str] = []   # [(level, text)] 用元组拆开存
+        heading_levels: List[int] = []
+        current_lines: List[str] = []
+        current_heading = ""
+
+        in_fence = False
+        fence_marker = ""
+
+        def flush():
+            text = "\n".join(current_lines).strip()
+            if text or current_heading:
+                sections.append((current_heading, text))
+
+        for line in lines:
+            stripped = line.strip()
+
+            # 代码围栏内的 # 不是标题
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                if not in_fence:
+                    in_fence, fence_marker = True, stripped[:3]
+                    current_lines.append(line)
+                    continue
+                if stripped.startswith(fence_marker):
+                    in_fence, fence_marker = False, ""
+                current_lines.append(line)
+                continue
+
+            m = HEADING_RE.match(line) if not in_fence else None
+            if m:
+                flush()
+                current_lines = []
+                level = len(m.group(1))
+                text = m.group(2).strip()
+                # 弹出更深或同级的标题
+                while heading_levels and heading_levels[-1] >= level:
+                    heading_stack.pop()
+                    heading_levels.pop()
+                heading_stack.append(text)
+                heading_levels.append(level)
+                current_heading = " > ".join(heading_stack)
+                current_lines.append(line)  # 标题行保留在块内
+            else:
+                current_lines.append(line)
+
+        flush()
+        return sections
+
+    # ---------- 二级切分：超长节按段落 ----------
+
+    def _split_long_section(self, text: str) -> List[str]:
+        if len(text) <= self.max_chars:
+            return [text]
+
+        paragraphs = self._split_paragraphs(text)
+        pieces: List[str] = []
+        buf: List[str] = []
+        buf_len = 0
+
+        for para in paragraphs:
+            # 单段超限：硬切（保留 overlap）
+            if len(para) > self.max_chars:
+                if buf:
+                    pieces.append("\n\n".join(buf))
+                    buf, buf_len = [], 0
+                step = self.max_chars - self.overlap_chars
+                for start in range(0, len(para), step):
+                    piece = para[start:start + self.max_chars]
+                    if len(piece) > self.min_chars:
+                        pieces.append(piece)
+                continue
+
+            if buf_len + len(para) + 2 > self.max_chars and buf:
+                pieces.append("\n\n".join(buf))
+                # 携带尾部 overlap（保留最后一个不超过 overlap 的段落）
+                tail = ""
+                for prev in reversed(buf):
+                    if len(tail) + len(prev) + 2 > self.overlap_chars:
+                        break
+                    tail = (prev + "\n\n" + tail) if tail else prev
+                buf = [tail] if tail else []
+                buf_len = len(tail)
+            buf.append(para)
+            buf_len += len(para) + 2
+
+        if buf:
+            last = "\n\n".join(buf)
+            # 尾块太小则并入前块
+            if pieces and len(last) < self.min_chars:
+                pieces[-1] = pieces[-1] + "\n\n" + last
+            else:
+                pieces.append(last)
+        return pieces
+
+    def _split_paragraphs(self, text: str) -> List[str]:
+        """按空行分段；代码围栏、表格行保持为不可分割单元"""
+        paragraphs: List[str] = []
+        buf: List[str] = []
+        in_fence = False
+        fence_marker = ""
+
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                if not in_fence:
+                    in_fence, fence_marker = True, stripped[:3]
+                    buf.append(line)
+                    continue
+                if stripped.startswith(fence_marker):
+                    in_fence, fence_marker = False, ""
+                buf.append(line)
+                continue
+            if not in_fence and not stripped and buf:
+                paragraphs.append("\n".join(buf))
+                buf = []
+            else:
+                buf.append(line)
+        if buf:
+            paragraphs.append("\n".join(buf))
+        return [p for p in paragraphs if p.strip()]

--- a/backend/modules/rag/service.py
+++ b/backend/modules/rag/service.py
@@ -1,0 +1,98 @@
+"""RagService - WikiService 之上的分块检索服务
+
+职责（M1）：
+- 挂载在现有 WikiService 之上，按 mtime 增量同步分块索引；
+- 对外提供 search_chunks（块级检索，注入用）；
+- 持久化到 workspace/wiki/chunk_index.json，与现有 bm25_index.json 并存。
+
+启用方式：环境变量 COUNTBOT_RAG_CHUNKS=1（见 wiki/tool.py）。
+"""
+
+from pathlib import Path
+from typing import List, Optional
+
+from loguru import logger
+
+
+class RagService:
+    """分块检索服务（包装 WikiService）"""
+
+    INDEX_FILENAME = "chunk_index.json"
+
+    def __init__(self, wiki_service, wiki_dir: Path):
+        """依赖显式注入：wiki_service 仅用于读取文档，路径由调用方传入，
+        不触碰 WikiService 私有属性。"""
+        self._wiki = wiki_service
+        self._concepts_dir = wiki_dir / "concepts"
+        self._index_file = wiki_dir / self.INDEX_FILENAME
+
+        from .stores import ChunkedBM25Index
+        self._store = ChunkedBM25Index()
+
+        if not self._store.load_from_file(str(self._index_file)):
+            logger.info("Chunk index not found, building from wiki files")
+            self.sync()
+
+    # ---------- 同步 ----------
+
+    def sync(self) -> dict:
+        """增量同步：对照 concepts/*.md 的 mtime，增删改对应文档的块"""
+        stats = {"added": 0, "updated": 0, "deleted": 0}
+
+        current: dict = {}
+        for md_file in self._concepts_dir.glob("*.md"):
+            current[md_file.stem] = md_file.stat().st_mtime
+
+        # 删除已不存在的文档
+        for slug in self._store.known_slugs():
+            if slug not in current:
+                self._store.remove_document(slug)
+                stats["deleted"] += 1
+
+        for slug, mtime in current.items():
+            if not self._store.has_document(slug):
+                action = "added"
+            elif mtime > self._store.get_mtime(slug):
+                action = "updated"
+            else:
+                continue
+            doc = self._wiki.get_document(slug)
+            if not doc:
+                continue
+            self._store.add_document(slug, doc["title"], doc["content"], doc.get("tags", []), mtime=mtime)
+            stats[action] += 1
+
+        if any(stats.values()):
+            self._store.save_to_file(str(self._index_file))
+            logger.info(f"Chunk index synced: +{stats['added']} ~{stats['updated']} -{stats['deleted']}")
+        return stats
+
+    # ---------- 文档变更钩子（tool 层 create/update/delete 后调用） ----------
+
+    def on_document_added(self, slug: str) -> int:
+        """单文档重建：只重新分块该文档（add_document 先删旧块再切块），
+        避免一次全量 sync。返回该文档的块数。"""
+        doc = self._wiki.get_document(slug)
+        if not doc:
+            return 0
+        md_file = self._concepts_dir / f"{slug}.md"
+        mtime = md_file.stat().st_mtime if md_file.exists() else 0.0
+        n = self._store.add_document(
+            slug, doc["title"], doc["content"], doc.get("tags", []), mtime=mtime
+        )
+        self._store.save_to_file(str(self._index_file))
+        logger.debug(f"Chunk index rebuilt for '{slug}': {n} chunks")
+        return n
+
+    def on_document_removed(self, slug: str) -> None:
+        self._store.remove_document(slug)
+        self._store.save_to_file(str(self._index_file))
+
+    # ---------- 检索 ----------
+
+    def search_chunks(self, query: str, top_k: int = 6, min_score_ratio: float = 0.3) -> List[dict]:
+        """块级检索：返回 [{chunk_id, slug, doc_title, section, score, content}]"""
+        return self._store.search_chunks(query, top_k=top_k, min_score_ratio=min_score_ratio)
+
+    def stats(self) -> dict:
+        return self._store.stats()

--- a/backend/modules/rag/stores/__init__.py
+++ b/backend/modules/rag/stores/__init__.py
@@ -1,0 +1,3 @@
+"""stores - RAG 检索存储层"""
+
+from .bm25_store import ChunkedBM25Index  # noqa: F401

--- a/backend/modules/rag/stores/bm25_store.py
+++ b/backend/modules/rag/stores/bm25_store.py
@@ -1,0 +1,166 @@
+"""分块级 BM25 索引 - 复用 wiki 的 BM25Index
+
+设计：每个 Chunk 作为 BM25Index 的一个"文档"（doc_id = chunk_id，
+title = "文档标题 · 节路径"，content = 块正文，tags = 文档标签），
+从而完整复用现有实现：jieba 分词、标题 ×3 / 标签 ×2 加权、倒排索引、
+IDF、持久化。零算法重写。
+
+slug -> chunk_id 的映射由 _slug_chunks 维护，支持按文档增删。
+"""
+
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from backend.modules.rag.chunker import Chunk, HeadingChunker
+from backend.modules.wiki.index import BM25Index
+
+
+class ChunkedBM25Index:
+    """以块为检索单元的 BM25 索引"""
+
+    def __init__(self, chunker: Optional[HeadingChunker] = None):
+        self._bm25 = BM25Index()
+        self._chunker = chunker or HeadingChunker()
+        # chunk 元数据（slug/section/doc_title），BM25Index 里只存复合标题
+        self._chunk_meta: Dict[str, dict] = {}
+        # slug -> {mtime, chunk_ids}
+        self._slug_registry: Dict[str, dict] = {}
+        # chunk_id -> slug（快速反查）
+        self._chunk_slug: Dict[str, str] = {}
+
+    # ---------- 文档级 API（与 BM25Index 同形，便于上层替换） ----------
+
+    def add_document(self, slug: str, title: str, content: str,
+                     tags: List[str] = None, mtime: float = 0) -> int:
+        """添加/替换文档（先移除旧块再切块），返回块数"""
+        self._remove_slug(slug)
+        chunks = self._chunker.chunk(slug, title, content, tags or [], mtime=mtime)
+        for c in chunks:
+            self._add_chunk(c)
+        self._slug_registry[slug] = {"mtime": mtime, "chunk_ids": [c.chunk_id for c in chunks]}
+        return len(chunks)
+
+    def remove_document(self, slug: str) -> None:
+        self._remove_slug(slug)
+
+    def _remove_slug(self, slug: str) -> None:
+        info = self._slug_registry.pop(slug, None)
+        if not info:
+            return
+        for chunk_id in info["chunk_ids"]:
+            self._bm25.remove_document(chunk_id)
+            self._chunk_meta.pop(chunk_id, None)
+            self._chunk_slug.pop(chunk_id, None)
+
+    def _add_chunk(self, c: Chunk) -> None:
+        self._bm25.add_document(c.chunk_id, c.index_title, c.content, c.tags, mtime=c.mtime)
+        self._chunk_meta[c.chunk_id] = {
+            "slug": c.slug,
+            "doc_title": c.doc_title,
+            "section": c.section,
+            "heading_path": c.heading_path,
+            "tags": c.tags,
+        }
+        self._chunk_slug[c.chunk_id] = c.slug
+
+    def get_mtime(self, slug: str) -> float:
+        return self._slug_registry.get(slug, {}).get("mtime", 0.0)
+
+    def has_document(self, slug: str) -> bool:
+        """该文档是否已在索引中（公共 API，避免上层触碰 _slug_registry）"""
+        return slug in self._slug_registry
+
+    def known_slugs(self) -> List[str]:
+        """已索引文档的 slug 列表（公共 API）"""
+        return list(self._slug_registry.keys())
+
+    # ---------- 检索 ----------
+
+    def search(self, query: str, top_k: int = 10, min_score_ratio: float = 0.3) -> List[Tuple[str, float]]:
+        """搜索块，返回 [(chunk_id, score)]"""
+        return self._bm25.search(query, top_k=top_k, min_score_ratio=min_score_ratio)
+
+    def search_chunks(self, query: str, top_k: int = 10, min_score_ratio: float = 0.3) -> List[dict]:
+        """搜索块，返回带元数据与正文的结果（注入用）"""
+        results = self.search(query, top_k=top_k, min_score_ratio=min_score_ratio)
+        out = []
+        for chunk_id, score in results:
+            meta = self._chunk_meta.get(chunk_id)
+            if not meta:
+                continue
+            content = self._bm25.documents.get(chunk_id, {}).get("content", "")
+            out.append({
+                "chunk_id": chunk_id,
+                "slug": meta["slug"],
+                "doc_title": meta["doc_title"],
+                "section": meta["section"],
+                "score": score,
+                "content": content,
+            })
+        return out
+
+    def get_chunk(self, chunk_id: str) -> Optional[dict]:
+        meta = self._chunk_meta.get(chunk_id)
+        if not meta:
+            return None
+        doc = self._bm25.documents.get(chunk_id, {})
+        return {**meta, "chunk_id": chunk_id, "content": doc.get("content", "")}
+
+    # ---------- 统计 ----------
+
+    def stats(self) -> dict:
+        return {
+            "total_docs": len(self._slug_registry),
+            "total_chunks": len(self._chunk_meta),
+            "unique_terms": len(self._bm25._inverted_index),
+            "avg_chunk_length": self._bm25.avg_doc_length,
+        }
+
+    # ---------- 持久化 ----------
+
+    def save_to_file(self, path: str) -> None:
+        data = {
+            "bm25": {
+                "documents": self._bm25.documents,
+                "doc_lengths": self._bm25.doc_lengths,
+                "avg_doc_length": self._bm25.avg_doc_length,
+                "total_docs": self._bm25.total_docs,
+                "inverted_index": {
+                    t: dict(df) for t, df in self._bm25._inverted_index.items()
+                },
+                "idf_cache": self._bm25._idf_cache,
+            },
+            "chunk_meta": self._chunk_meta,
+            "chunk_slug": self._chunk_slug,
+            "slug_registry": self._slug_registry,
+        }
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False)
+
+    def load_from_file(self, path: str) -> bool:
+        p = Path(path)
+        if not p.exists():
+            return False
+        try:
+            with open(p, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            bm25_data = data["bm25"]
+            self._bm25 = BM25Index()
+            self._bm25.documents = bm25_data.get("documents", {})
+            self._bm25.doc_lengths = bm25_data.get("doc_lengths", {})
+            self._bm25.avg_doc_length = bm25_data.get("avg_doc_length", 0.0)
+            self._bm25.total_docs = bm25_data.get("total_docs", 0)
+            self._bm25._inverted_index = defaultdict(lambda: defaultdict(int))
+            for t, df in bm25_data.get("inverted_index", {}).items():
+                for cid, freq in df.items():
+                    self._bm25._inverted_index[t][cid] = freq
+            self._bm25._idf_cache = bm25_data.get("idf_cache", {})
+            self._chunk_meta = data.get("chunk_meta", {})
+            self._chunk_slug = data.get("chunk_slug", {})
+            self._slug_registry = data.get("slug_registry", {})
+            return True
+        except Exception:
+            return False

--- a/backend/modules/wiki/tool.py
+++ b/backend/modules/wiki/tool.py
@@ -1,11 +1,17 @@
 """Wiki Tool - Agent工具接口"""
 
+import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 from loguru import logger
 
 from backend.modules.tools.base import Tool
 from .service import WikiService
+
+
+def _rag_chunks_enabled() -> bool:
+    """M1 分块检索回滚开关：COUNTBOT_RAG_CHUNKS=1 启用，缺省关闭（零行为变化）"""
+    return os.environ.get("COUNTBOT_RAG_CHUNKS", "").lower() in ("1", "true", "yes", "on")
 
 
 class WikiTool(Tool):
@@ -24,7 +30,17 @@ class WikiTool(Tool):
     """
 
     def __init__(self, wiki_dir: Optional[Path] = None):
-        self._service = WikiService(wiki_dir or Path("workspace/wiki"))
+        self._wiki_dir = wiki_dir or Path("workspace/wiki")
+        self._service = WikiService(self._wiki_dir)
+        self._rag = None
+        if _rag_chunks_enabled():
+            try:
+                from backend.modules.rag.service import RagService
+                self._rag = RagService(self._service, self._wiki_dir)
+                logger.info("RAG chunk-level retrieval enabled (COUNTBOT_RAG_CHUNKS=1)")
+            except Exception as e:
+                logger.warning(f"RAG chunk service unavailable, falling back to doc-level: {e}")
+                self._rag = None
 
     @property
     def name(self) -> str:
@@ -134,6 +150,9 @@ class WikiTool(Tool):
         if not query:
             return "Error: search action requires 'query' parameter"
 
+        if self._rag:
+            return self._rag_search(query, top_k)
+
         # 使用优化的搜索方法，包含元数据和相关性过滤
         results = self._service.search_with_metadata(query, top_k=top_k, min_score_ratio=0.3)
 
@@ -172,6 +191,9 @@ class WikiTool(Tool):
         if not question:
             return "Error: ask action requires 'query' parameter"
 
+        if self._rag:
+            return await self._rag_ask(question)
+
         results = self._service.search(question, top_k=3)
 
         if not results:
@@ -208,6 +230,67 @@ class WikiTool(Tool):
             return await provider.chat_completion(prompt, max_tokens=2000, temperature=0.3)
         except Exception:
             return self._format_search_results(results)
+
+    # ---------- M1: 块级检索路径（COUNTBOT_RAG_CHUNKS=1 时生效） ----------
+
+    def _rag_search(self, query: str, top_k: int) -> str:
+        """块级搜索：返回条目 + 具体节，带 [slug#section] 溯源标识"""
+        chunks = self._rag.search_chunks(query, top_k=top_k)
+        if not chunks:
+            return f"No wiki entries found for: {query}"
+
+        max_score = chunks[0]["score"]
+        lines = [f"Found {len(chunks)} matching sections for '{query}':\n"]
+        for i, c in enumerate(chunks, 1):
+            if c["score"] >= max_score * 0.8:
+                quality = " [高相关]"
+            elif c["score"] >= max_score * 0.5:
+                quality = " [相关]"
+            else:
+                quality = " [低相关]"
+            lines.append(f"{i}. **{c['doc_title']}** › {c['section']} (score: {c['score']:.2f}){quality}")
+            lines.append(f"   Source: {c['chunk_id']}")
+            if c.get("tags"):
+                lines.append(f"   Tags: {', '.join(c['tags'])}")
+            summary = c["content"].strip()[:200]
+            lines.append(f"   {summary}")
+            lines.append("")
+        return "\n".join(lines)
+
+    async def _rag_ask(self, question: str) -> str:
+        """块级问答：注入 top-K 相关块（而非整篇），带溯源"""
+        chunks = self._rag.search_chunks(question, top_k=6)
+        if not chunks:
+            return "Wiki 知识库为空或没有找到相关内容。"
+
+        context_parts = []
+        for c in chunks:
+            context_parts.append(
+                f"### {c['doc_title']} › {c['section']}\n(来源: {c['chunk_id']})\n{c['content']}"
+            )
+        context = "\n\n".join(context_parts)
+
+        try:
+            from backend.app import get_shared_provider
+            provider = get_shared_provider()
+
+            if not provider:
+                return self._rag_search(question, top_k=6)
+
+            prompt = f"""请根据以下 Wiki 知识库内容回答问题。引用时注明来源 [slug#section]。
+
+问题：{question}
+
+---
+
+{context}
+
+---
+
+如果知识库中没有相关内容，请如实告知。"""
+            return await provider.chat_completion(prompt, max_tokens=2000, temperature=0.3)
+        except Exception:
+            return self._rag_search(question, top_k=6)
 
     def _handle_get(self, slug: Optional[str]) -> str:
         """处理获取请求"""
@@ -335,6 +418,8 @@ class WikiTool(Tool):
 
             # 更新索引
             self._service.add_document(slug, title, content, tags or [])
+            if self._rag:
+                self._rag.on_document_added(slug)
 
             logger.info(f"Created wiki entry: {slug}")
             return f"✓ Created wiki entry: **{title}** (slug: {slug})\nTags: {', '.join(tags or [])}"
@@ -382,6 +467,8 @@ class WikiTool(Tool):
                 post.content,
                 post.metadata.get("tags", [])
             )
+            if self._rag:
+                self._rag.on_document_added(slug)
 
             logger.info(f"Updated wiki entry: {slug}")
             return f"✓ Updated wiki entry: **{post.metadata.get('title', slug)}** (slug: {slug})\nUpdated fields: {', '.join(updated_fields)}"
@@ -409,6 +496,8 @@ class WikiTool(Tool):
 
             # 更新索引
             self._service.remove_document(slug)
+            if self._rag:
+                self._rag.on_document_removed(slug)
 
             logger.info(f"Deleted wiki entry: {slug}")
             return f"✓ Deleted wiki entry: **{title}** (slug: {slug})"
@@ -420,6 +509,13 @@ class WikiTool(Tool):
         """处理同步请求"""
         try:
             stats = self._service.force_sync()
+            if self._rag:
+                rag_stats = self._rag.sync()
+                stats = {
+                    "added": stats["added"] + rag_stats["added"],
+                    "updated": stats["updated"] + rag_stats["updated"],
+                    "deleted": stats["deleted"] + rag_stats["deleted"],
+                }
             return (
                 f"✓ Index synchronized:\n"
                 f"• Added: {stats['added']} new entries\n"

--- a/backend/modules/wiki/tool.py
+++ b/backend/modules/wiki/tool.py
@@ -1,8 +1,10 @@
 """Wiki Tool - Agent工具接口"""
 
+import json
 import os
+import re
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from loguru import logger
 
 from backend.modules.tools.base import Tool
@@ -258,10 +260,140 @@ class WikiTool(Tool):
         return "\n".join(lines)
 
     async def _rag_ask(self, question: str) -> str:
-        """块级问答：注入 top-K 相关块（而非整篇），带溯源"""
+        """块级问答：检索 → LLM 评估相关性 → 三段路由（直接生成 / 过滤后生成 / 改写重试后拒答）。
+
+        评估不可用（无 provider / 调用失败 / 输出不可解析）时回退为
+        "全部注入直接生成"（即评估前的行为），保证零破坏。
+        """
         chunks = self._rag.search_chunks(question, top_k=6)
         if not chunks:
             return "Wiki 知识库为空或没有找到相关内容。"
+
+        grade, relevant = await self._grade_chunks(question, chunks)
+
+        if grade == "none":
+            # 检索结果全不相关：改写问题重试一次，仍不相关则如实拒答
+            rewritten = await self._rewrite_query(question)
+            if rewritten and rewritten != question:
+                chunks2 = self._rag.search_chunks(rewritten, top_k=6)
+                if chunks2:
+                    grade2, relevant2 = await self._grade_chunks(rewritten, chunks2)
+                    if grade2 == "all":
+                        return await self._generate_from_chunks(rewritten, chunks2)
+                    if grade2 == "partial":
+                        return await self._generate_from_chunks(
+                            rewritten, self._filter_chunks(chunks2, relevant2) or chunks2
+                        )
+            return ("Wiki 知识库中没有找到与该问题相关的内容。"
+                    "（已检索并逐条校验相关性，结果均与问题无关；"
+                    "可以换个问法重试，或确认知识库中是否已有相关条目。）")
+
+        if grade == "partial" and relevant:
+            chunks = self._filter_chunks(chunks, relevant) or chunks
+
+        return await self._generate_from_chunks(question, chunks)
+
+    # ---------- 块级问答的评估与路由组件（仅 COUNTBOT_RAG_CHUNKS=1 路径使用） ----------
+
+    @staticmethod
+    def _get_provider():
+        """获取共享 LLM provider；不可用时返回 None（各调用方自行回退）"""
+        try:
+            from backend.app import get_shared_provider
+            return get_shared_provider()
+        except Exception:
+            return None
+
+    async def _grade_chunks(self, question: str, chunks: List[dict]) -> Tuple[Optional[str], Optional[List[int]]]:
+        """LLM 评估检索块与问题的相关性（单次轻量调用，约 200-400 token）。
+
+        Returns:
+            ("all"|"partial"|"none", relevant_ids)；评估不可用时 (None, None)。
+            纯分数阈值无法做拒答：实测负样本 top1 分数与正样本重叠率 7/10。
+        """
+        provider = self._get_provider()
+        if provider is None:
+            return None, None
+
+        lines = [
+            f"{i}. {c['doc_title']} › {c['section']}：{c['content'].strip()[:120]}"
+            for i, c in enumerate(chunks, 1)
+        ]
+        prompt = (
+            "你是知识库检索质量评估器。判断下面的检索结果能否支撑回答问题。\n\n"
+            f"问题：{question}\n\n"
+            "检索结果（编号. 文档 › 章节：内容摘录）：\n" + "\n".join(lines) + "\n\n"
+            '只输出一行 JSON，不要输出其他内容：\n'
+            '{"grade": "all|partial|none", "relevant": [相关编号]}\n'
+            "- all：检索结果基本都与问题相关，足以回答\n"
+            "- partial：有任何一条结果可能包含与问题相关的信息"
+            "（哪怕只覆盖问题的一部分、或只提供部分线索），"
+            "relevant 列出这些结果的编号\n"
+            "- none：仅当所有结果谈论的都是与问题完全无关的主题时使用；"
+            "拿不准时优先 partial，不要轻易判 none"
+        )
+        try:
+            resp = await provider.chat_completion(prompt, max_tokens=200, temperature=0.0)
+            return self._parse_grade(resp, len(chunks))
+        except Exception as e:
+            logger.warning(f"Chunk grading failed, falling back to plain generation: {e}")
+            return None, None
+
+    @staticmethod
+    def _parse_grade(text: str, n_chunks: int) -> Tuple[Optional[str], Optional[List[int]]]:
+        """解析评估输出为 (grade, relevant_ids)；不可解析时返回 (None, None)"""
+        if not text:
+            return None, None
+        m = re.search(r"\{[^{}]*\}", text, re.S)
+        if not m:
+            return None, None
+        try:
+            data = json.loads(m.group(0))
+        except Exception:
+            return None, None
+        grade = str(data.get("grade", "")).strip().lower()
+        if grade not in ("all", "partial", "none"):
+            return None, None
+        ids = set()
+        for i in (data.get("relevant") or []):
+            try:
+                n = int(i)
+            except (TypeError, ValueError):
+                continue
+            if 1 <= n <= n_chunks:
+                ids.add(n)
+        return grade, sorted(ids)
+
+    async def _rewrite_query(self, question: str) -> Optional[str]:
+        """全不相关时，让 LLM 把问题改写为更贴近知识库术语的检索词（一次机会）"""
+        provider = self._get_provider()
+        if provider is None:
+            return None
+        prompt = (
+            "把下面的问题改写成更适合知识库关键词检索的问法"
+            "（保留原意，尽量使用文档中可能出现的术语，不要回答问题本身），"
+            "只输出改写后的问题：\n" + question
+        )
+        try:
+            resp = await provider.chat_completion(prompt, max_tokens=100, temperature=0.0)
+            text = (resp or "").strip().strip('"').strip("\u201c\u201d")
+            return text or None
+        except Exception as e:
+            logger.warning(f"Query rewrite failed: {e}")
+            return None
+
+    @staticmethod
+    def _filter_chunks(chunks: List[dict], relevant_ids: List[int]) -> List[dict]:
+        """按评估给出的编号保留相关块（编号从 1 开始）"""
+        if not relevant_ids:
+            return []
+        return [c for i, c in enumerate(chunks, 1) if i in set(relevant_ids)]
+
+    async def _generate_from_chunks(self, question: str, chunks: List[dict]) -> str:
+        """用给定块组装上下文并生成回答；无 provider 或失败时回退块级搜索结果"""
+        provider = self._get_provider()
+        if not provider:
+            return self._rag_search(question, top_k=6)
 
         context_parts = []
         for c in chunks:
@@ -270,14 +402,7 @@ class WikiTool(Tool):
             )
         context = "\n\n".join(context_parts)
 
-        try:
-            from backend.app import get_shared_provider
-            provider = get_shared_provider()
-
-            if not provider:
-                return self._rag_search(question, top_k=6)
-
-            prompt = f"""请根据以下 Wiki 知识库内容回答问题。引用时注明来源 [slug#section]。
+        prompt = f"""请根据以下 Wiki 知识库内容回答问题。引用时注明来源 [slug#section]。
 
 问题：{question}
 
@@ -288,6 +413,7 @@ class WikiTool(Tool):
 ---
 
 如果知识库中没有相关内容，请如实告知。"""
+        try:
             return await provider.chat_completion(prompt, max_tokens=2000, temperature=0.3)
         except Exception:
             return self._rag_search(question, top_k=6)

--- a/rag-bench/questions.jsonl
+++ b/rag-bench/questions.jsonl
@@ -1,0 +1,60 @@
+{"id": "S1-01", "type": "single_doc", "semantic": false, "question": "CountBot 的长期记忆存储在哪里？是什么格式的文件？", "expected_points": ["工作空间中的单文件存储", "JSON 格式，可直接查看编辑"], "source_pages": ["core/memory.md"]}
+{"id": "S1-02", "type": "single_doc", "semantic": false, "question": "CountBot 记忆条目的格式长什么样？包含哪些字段？", "expected_points": ["条目字段结构（id/时间戳/内容/来源等）"], "source_pages": ["core/memory.md"]}
+{"id": "S1-03", "type": "single_doc", "semantic": false, "question": "什么是 auto-overflow 记忆？什么情况下会产生？", "expected_points": ["会话历史超出窗口限制时", "旧消息被压缩写入记忆，来源标记为 auto-overflow"], "source_pages": ["core/memory.md"]}
+{"id": "S1-04", "type": "single_doc", "semantic": false, "question": "AI 模型是怎么读写长期记忆的？需要直接操作文件吗？", "expected_points": ["通过工具调用读写", "模型不直接操作文件"], "source_pages": ["core/memory.md"]}
+{"id": "S1-05", "type": "single_doc", "semantic": false, "question": "CountBot 有哪几种启动方式？分别用什么命令？", "expected_points": ["start_app.py / start_desktop.py / start_dev.py 等启动脚本及区别"], "source_pages": ["getting-started/installation.md"]}
+{"id": "S1-06", "type": "single_doc", "semantic": false, "question": "CountBot 对运行环境有什么要求？需要什么版本的 Python？", "expected_points": ["Python 版本要求", "操作系统支持情况"], "source_pages": ["getting-started/installation.md"]}
+{"id": "S1-07", "type": "single_doc", "semantic": false, "question": "怎么让局域网内其他设备访问 CountBot 的 Web 界面？", "expected_points": ["COUNTBOT_HOST=0.0.0.0 环境变量", "通过本机 IP+端口访问"], "source_pages": ["getting-started/installation.md"]}
+{"id": "S1-08", "type": "single_doc", "semantic": false, "question": "桌面版相比 Web 版有什么限制？", "expected_points": ["桌面版功能边界", "系统依赖差异（libwebkit2gtk）"], "source_pages": ["getting-started/installation.md"]}
+{"id": "S1-09", "type": "single_doc", "semantic": false, "question": "requirements.txt 里的依赖是怎么分类的？", "expected_points": ["依赖分组结构（核心/渠道/桌面等分类方式）"], "source_pages": ["getting-started/installation.md"]}
+{"id": "S1-10", "type": "single_doc", "semantic": false, "question": "CountBot 启动后的自检清单有哪些检查项？", "expected_points": ["启动自检项列表（配置/网络/渠道等）"], "source_pages": ["getting-started/installation.md"]}
+{"id": "S1-11", "type": "single_doc", "semantic": false, "question": "workspace 工作空间目录里都有哪些内容？", "expected_points": ["skills/、memory/、temp/、.skills_config.json 等结构"], "source_pages": ["getting-started/configuration-manual.md"]}
+{"id": "S1-12", "type": "single_doc", "semantic": false, "question": "前端构建产物放在哪个目录？", "expected_points": ["frontend/dist/"], "source_pages": ["advanced/deployment.md"]}
+{"id": "S1-13", "type": "single_doc", "semantic": false, "question": "后端 lifespan 的初始化顺序是什么？", "expected_points": ["数据库初始化→加载配置→共享组件→消息队列→渠道→消息处理→Cron→心跳等顺序"], "source_pages": ["advanced/deployment.md"]}
+{"id": "S1-14", "type": "single_doc", "semantic": false, "question": "CountBot 内置支持多少个模型 provider？", "expected_points": ["22 个"], "source_pages": ["core/providers.md"]}
+{"id": "S1-15", "type": "single_doc", "semantic": false, "question": "Cron 定时任务底层用什么调度库实现？", "expected_points": ["APScheduler"], "source_pages": ["core/cron.md"]}
+{"id": "S1-16", "type": "single_doc", "semantic": true, "question": "我想让 CountBot 到点自动干活，不用我发消息触发，能做到吗？", "expected_points": ["Cron 定时任务功能", "APScheduler 调度"], "source_pages": ["core/cron.md"]}
+{"id": "S1-17", "type": "single_doc", "semantic": true, "question": "CountBot 能在新的一次对话里想起我上次跟它说过的话吗？靠什么机制？", "expected_points": ["长期记忆机制", "跨会话记忆存储"], "source_pages": ["core/memory.md"]}
+{"id": "S1-18", "type": "single_doc", "semantic": true, "question": "一件复杂的事能让几个 AI 角色接力完成吗？", "expected_points": ["Agent 团队功能", "多角色协作"], "source_pages": ["core/agent-teams.md"]}
+{"id": "S1-19", "type": "single_doc", "semantic": true, "question": "我平时在终端里用 AI 编码工具写代码，CountBot 能直接调用它吗？", "expected_points": ["外部编码工具集成（Claude Code/Codex 等）"], "source_pages": ["core/external-coding-tools.md"]}
+{"id": "S1-20", "type": "single_doc", "semantic": true, "question": "同事想在他自己的电脑上打开我的 CountBot 页面来用，行得通吗？", "expected_points": ["远程访问方案", "局域网/公网暴露与认证"], "source_pages": ["advanced/remote-access.md"]}
+{"id": "S1-21", "type": "single_doc", "semantic": true, "question": "知识库文档越存越多，查询会越来越慢吗？", "expected_points": ["Wiki LRU 缓存机制", "缓存容量 128 个文档，重复查询性能提升"], "source_pages": ["releases/v0.9.0.md"]}
+{"id": "S1-22", "type": "single_doc", "semantic": true, "question": "我有好几个 API Key，一个额度用完了能自动换下一个吗？", "expected_points": ["API Key 轮换机制", "401/429 触发自动切换"], "source_pages": ["releases/v0.9.0.md"]}
+{"id": "S1-23", "type": "single_doc", "semantic": true, "question": "我在两个不同的群里分别跟 CountBot 聊，它会把两边的话题记混吗？", "expected_points": ["会话按渠道/聊天隔离", "channels 会话作用域"], "source_pages": ["core/channels.md"]}
+{"id": "S1-24", "type": "single_doc", "semantic": true, "question": "聊到一半想抛开前面的话题重新开始，有什么办法？", "expected_points": ["/new 等斜杠命令重开会话"], "source_pages": ["core/im-commands.md"]}
+{"id": "S1-25", "type": "single_doc", "semantic": true, "question": "升级到新版本的时候，我之前的会话和记忆还能保住吗？", "expected_points": ["升级保留数据", "backup/数据兼容说明"], "source_pages": ["getting-started/update-guide.md"]}
+{"id": "S2-01", "type": "cross_doc", "semantic": false, "question": "怎么配置 CountBot 每天早上 8 点自动搜索新闻并发送到 Telegram？", "expected_points": ["Cron 定时任务配置", "Telegram 渠道配置", "搜索技能与消息发送联动"], "source_pages": ["core/cron.md", "core/channels.md", "scenarios/每天早上一条消息搞定全天：AI早报自动生成的场景与调度技巧.md"]}
+{"id": "S2-02", "type": "cross_doc", "semantic": false, "question": "我在家用桌面版运行 CountBot，出差在外能用手机浏览器访问吗？", "expected_points": ["远程访问方案", "桌面版运行特点", "认证与安全"], "source_pages": ["getting-started/installation.md", "advanced/remote-access.md"]}
+{"id": "S2-03", "type": "cross_doc", "semantic": false, "question": "钉钉上配置完成后机器人不回复消息，应该怎么排查？", "expected_points": ["渠道配置检查", "troubleshooting 排查步骤"], "source_pages": ["getting-started/ChannelConfig.md", "getting-started/troubleshooting.md", "core/channels.md"]}
+{"id": "S2-04", "type": "cross_doc", "semantic": false, "question": "配置好模型 provider 之后，怎么验证连接是正常的？", "expected_points": ["测试模型连接的方式", "provider 状态检查"], "source_pages": ["core/providers.md", "getting-started/quick-reference.md"]}
+{"id": "S2-05", "type": "cross_doc", "semantic": false, "question": "子代理执行完任务之后，结果是怎么回到主对话里的？", "expected_points": ["子代理结果回传机制", "agent loop 中的汇合点"], "source_pages": ["core/subagent.md", "core/agent-loop.md"]}
+{"id": "S2-06", "type": "cross_doc", "semantic": false, "question": "Agent 团队里不同成员想用不同模型，怎么指定优先级？", "expected_points": ["团队成员模型配置", "provider 优先级"], "source_pages": ["core/agent-teams.md", "core/providers.md"]}
+{"id": "S2-07", "type": "cross_doc", "semantic": false, "question": "CountBot 执行 Shell 命令有什么安全限制？怎么防止危险命令？", "expected_points": ["Shell 工具限制", "安全机制（确认/黑名单等）"], "source_pages": ["core/tools.md", "advanced/security.md"]}
+{"id": "S2-08", "type": "cross_doc", "semantic": false, "question": "MCP 工具和外部编码工具（比如 Claude Code）有什么区别？分别什么场景用？", "expected_points": ["MCP 集成方式", "外部编码工具定位", "两者适用场景差异"], "source_pages": ["core/tools.md", "core/external-coding-tools.md"]}
+{"id": "S2-09", "type": "cross_doc", "semantic": false, "question": "什么前提下才能把消息路由到 direct 模式直接给编码工具处理？", "expected_points": ["/route direct 命令", "使用前提（需配置编码工具）"], "source_pages": ["core/im-commands.md", "core/external-coding-tools.md"]}
+{"id": "S2-10", "type": "cross_doc", "semantic": false, "question": "一个会话聊得特别长，系统会发生什么？", "expected_points": ["历史窗口限制", "自动总结触发（30 条/15000 字符）", "auto-overflow 记忆"], "source_pages": ["core/agent-loop.md", "advanced/http-api-deep-dive.md", "core/memory.md"]}
+{"id": "S2-11", "type": "cross_doc", "semantic": false, "question": "把 CountBot 部署在局域网给全组使用，有哪些安全注意事项？", "expected_points": ["认证机制", "API Key 保护", "网络安全配置"], "source_pages": ["advanced/deployment.md", "advanced/security.md", "advanced/remote-access.md"]}
+{"id": "S2-12", "type": "cross_doc", "semantic": false, "question": "升级到新版本之前需要做哪些准备工作？", "expected_points": ["备份", "依赖更新", "数据迁移注意事项"], "source_pages": ["getting-started/update-guide.md", "getting-started/installation.md"]}
+{"id": "S2-13", "type": "cross_doc", "semantic": false, "question": "能在 Web 界面上创建定时任务吗，还是只能改配置文件？", "expected_points": ["Web 界面任务管理", "cron 任务创建方式"], "source_pages": ["core/cron.md", "getting-started/quick-reference.md"]}
+{"id": "S2-14", "type": "cross_doc", "semantic": false, "question": "不想用云端的 API，能不能完全在本地跑模型来用 CountBot？", "expected_points": ["本地模型支持（Ollama 等）", "provider 配置方式", "性能取舍"], "source_pages": ["core/providers.md", "getting-started/installation.md"]}
+{"id": "S2-15", "type": "cross_doc", "semantic": false, "question": "用 /route 和 /coder 切换了路由之后，这些切换会记录进会话历史吗？", "expected_points": ["命令是否写入历史", "会话状态保持方式"], "source_pages": ["core/im-commands.md", "core/agent-loop.md"]}
+{"id": "S3-01", "type": "needle", "semantic": false, "question": "会话达到多少条消息会触发自动总结？", "expected_points": ["30 条"], "source_pages": ["advanced/http-api-deep-dive.md"]}
+{"id": "S3-02", "type": "needle", "semantic": false, "question": "自动总结的字符数阈值是多少？", "expected_points": ["15000 字符"], "source_pages": ["advanced/http-api-deep-dive.md"]}
+{"id": "S3-03", "type": "needle", "semantic": false, "question": "子代理最多允许迭代多少轮？", "expected_points": ["15"], "source_pages": ["core/subagent.md"]}
+{"id": "S3-04", "type": "needle", "semantic": false, "question": "Wiki 知识库的 LRU 缓存容量是多少个文档？", "expected_points": ["128"], "source_pages": ["releases/v0.9.0.md"]}
+{"id": "S3-05", "type": "needle", "semantic": false, "question": "v0.9.0 的心跳问候优化把每次的 LLM 调用次数从几次降到了几次？", "expected_points": ["从 2 次降到 1 次"], "source_pages": ["releases/v0.9.0.md"]}
+{"id": "S3-06", "type": "needle", "semantic": false, "question": "API Key 轮换是在收到哪些 HTTP 状态码时触发的？", "expected_points": ["401 和 429"], "source_pages": ["releases/v0.9.0.md"]}
+{"id": "S3-07", "type": "needle", "semantic": false, "question": "CountBot 内置支持多少个模型 provider？", "expected_points": ["22 个"], "source_pages": ["core/providers.md"]}
+{"id": "S3-08", "type": "needle", "semantic": false, "question": "SQLite 数据库文件叫什么名字？定时任务存在哪张表里？", "expected_points": ["countbot.db", "cron_jobs 表"], "source_pages": ["advanced/deployment.md"]}
+{"id": "S3-09", "type": "needle", "semantic": false, "question": "Telegram 的代理设置支持什么协议？", "expected_points": ["socks5://"], "source_pages": ["getting-started/troubleshooting.md"]}
+{"id": "S3-10", "type": "needle", "semantic": false, "question": "Linux 上安装桌面版需要额外装哪个系统依赖包？", "expected_points": ["libwebkit2gtk-4.0-37"], "source_pages": ["getting-started/installation.md"]}
+{"id": "S4-01", "type": "negative", "semantic": false, "question": "CountBot 怎么部署到 Kubernetes 集群上？", "expected_points": ["应拒答：官方不支持 K8s 部署"], "source_pages": []}
+{"id": "S4-02", "type": "negative", "semantic": false, "question": "CountBot 有官方手机 App 吗？在哪里下载？", "expected_points": ["应拒答：没有官方移动端 App"], "source_pages": []}
+{"id": "S4-03", "type": "negative", "semantic": false, "question": "CountBot 支持语音通话吗？", "expected_points": ["应拒答：不支持语音通话"], "source_pages": []}
+{"id": "S4-04", "type": "negative", "semantic": false, "question": "CountBot 能接入 Home Assistant 控制智能家居设备吗？", "expected_points": ["应拒答：无智能家居集成"], "source_pages": []}
+{"id": "S4-05", "type": "negative", "semantic": false, "question": "CountBot 商业版是怎么收费的？", "expected_points": ["应拒答：开源项目无商业定价"], "source_pages": []}
+{"id": "S4-06", "type": "negative", "semantic": false, "question": "可以把 CountBot 的 SQLite 换成 PostgreSQL 吗？官方支持吗？", "expected_points": ["应拒答：仅支持 SQLite，无 PostgreSQL 支持"], "source_pages": []}
+{"id": "S4-07", "type": "negative", "semantic": false, "question": "哪里可以下载 CountBot 的第三方插件？", "expected_points": ["应拒答：无插件市场"], "source_pages": []}
+{"id": "S4-08", "type": "negative", "semantic": false, "question": "CountBot 能运行在树莓派或 ARM 设备上吗？", "expected_points": ["应拒答：官方未支持 ARM/树莓派"], "source_pages": []}
+{"id": "S4-09", "type": "negative", "semantic": false, "question": "CountBot 支持 SSO 单点登录吗？", "expected_points": ["应拒答：无 SSO 支持"], "source_pages": []}
+{"id": "S4-10", "type": "negative", "semantic": false, "question": "CountBot 支持视频通话或者屏幕共享吗？", "expected_points": ["应拒答：不支持"], "source_pages": []}

--- a/rag-bench/scripts/fetch_corpus.py
+++ b/rag-bench/scripts/fetch_corpus.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""抓取 countbot.cn 官方文档站全量页面，转为 Markdown 语料。
+
+用途：RAG 基线测试（G0）的 C1/C2 语料构建。
+来源全部为官方公开页面，保证可复现。
+
+输出：
+  rag-bench/corpus/<slug>.md   —— 每页一份 Markdown（首行为 H1 标题）
+  rag-bench/corpus/manifest.json —— 抓取清单（slug/title/url/chars/est_tokens）
+
+用法：
+  python fetch_corpus.py [--out ../corpus]
+"""
+
+import json
+import re
+import sys
+import time
+import urllib.request
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import quote, unquote, urlparse
+
+BASE = "https://countbot.cn"
+UA = ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+      "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36")
+
+# 额外页面（llms.txt 列出但 sitemap 缺失：scenarios / 新版 releases / update-guide）
+EXTRA_PATHS = [
+    "/docs/scenarios/一句话清空收件箱：AI邮件分拣的场景拆解与提示词技巧/",
+    "/docs/scenarios/帮我做个网页然后上线：从需求描述到生产部署的完整话术/",
+    "/docs/scenarios/帮我搜一下最近AI有什么新动态：多源信息聚合的场景与检索技巧/",
+    "/docs/scenarios/帮我盯着这件事：定时监控与主动提醒的场景设计与自动化技巧/",
+    "/docs/scenarios/帮我规划一趟旅行：多技能联动的复合任务拆解与编排技巧/",
+    "/docs/scenarios/每天早上一条消息搞定全天：AI早报自动生成的场景与调度技巧/",
+    "/docs/releases/v0.7.0/",
+    "/docs/releases/v0.8.0/",
+    "/docs/releases/v0.9.0/",
+    "/docs/getting-started/update-guide/",
+]
+
+
+class ArticleToMarkdown(HTMLParser):
+    """把 <article> 内的 HTML 转为 Markdown 文本（容忍不完整标签）。
+
+    保留结构：h1-h6 标题、列表项、代码块（围栏）、表格（管道行）、引用。
+    行内标签只保留文本。script/style/svg/nav 忽略。
+    """
+
+    BLOCK_TAGS = {"p", "div", "section", "header", "footer", "br", "hr",
+                  "ul", "ol", "table", "thead", "tbody", "blockquote", "details", "summary"}
+    SKIP_TAGS = {"script", "style", "svg", "nav", "img", "button", "input"}
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.lines: list[str] = []
+        self._buf: list[str] = []
+        self._skip_depth = 0
+        self._pre_depth = 0
+        self._pre_buf: list[str] = []
+        self._in_cell = False
+        self._cell_buf: list[str] = []
+        self._row_cells: list[str] | None = None
+        self._is_header_row = False
+        self._list_depth = 0
+        self._li_open = False
+        self._quote = False
+
+    # ---------- 基础 ----------
+    def _text(self, s: str):
+        if self._skip_depth > 0:
+            return
+        if self._pre_depth > 0:
+            self._pre_buf.append(s)
+        elif self._in_cell:
+            self._cell_buf.append(s)
+        else:
+            self._buf.append(s)
+            if self._li_open:
+                self._li_open = False
+
+    def _flush_para(self):
+        text = re.sub(r"\s+", " ", "".join(self._buf)).strip()
+        self._buf = []
+        if not text:
+            return
+        prefix = "> " if self._quote else ""
+        indent = "  " * max(self._list_depth - 1, 0)
+        bullet = "- " if self._list_depth > 0 else ""
+        self.lines.append(prefix + indent + bullet + text)
+
+    def _flush_cell(self):
+        text = re.sub(r"\s+", " ", "".join(self._cell_buf)).strip()
+        self._cell_buf = []
+        if self._row_cells is not None:
+            self._row_cells.append(text)
+
+    # ---------- 标签处理 ----------
+    def handle_starttag(self, tag, attrs):
+        if tag in self.SKIP_TAGS:
+            self._skip_depth += 1
+            return
+        if self._skip_depth > 0:
+            return
+        if tag == "pre":
+            self._flush_para()
+            self._pre_depth += 1
+            if self._pre_depth == 1:
+                self._pre_buf = []
+        elif tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            self._flush_para()
+            self._buf.append("\x00H%d\x00" % int(tag[1]))  # 标记，flush 时替换
+        elif tag in ("p", "div", "section", "header", "footer", "blockquote",
+                     "details", "summary", "ul", "ol", "table", "thead", "tbody"):
+            self._flush_para()
+            if tag == "blockquote":
+                self._quote = True
+            elif tag in ("ul", "ol"):
+                self._list_depth += 1
+        elif tag == "li":
+            self._flush_para()
+            self._li_open = True
+        elif tag == "tr":
+            self._row_cells = []
+        elif tag in ("td", "th"):
+            self._in_cell = True
+            if tag == "th":
+                self._is_header_row = True
+        elif tag == "br":
+            self._text(" ")
+        elif tag == "hr":
+            self._flush_para()
+            self.lines.append("---")
+
+    def handle_endtag(self, tag):
+        if tag in self.SKIP_TAGS:
+            self._skip_depth = max(0, self._skip_depth - 1)
+            return
+        if self._skip_depth > 0:
+            return
+        if tag == "pre":
+            self._pre_depth -= 1
+            if self._pre_depth == 0:
+                code = "".join(self._pre_buf).rstrip("\n")
+                self.lines.append("```\n" + code + "\n```")
+        elif tag in ("h1", "h2", "h3", "h4", "h5", "h6"):
+            level = int(tag[1])
+            raw = "".join(self._buf)
+            self._buf = []
+            text = re.sub(r"\s+", " ", raw.replace("\x00H%d\x00" % level, "")).strip()
+            prefix = "> " if self._quote else ""
+            self.lines.append(prefix + "#" * level + " " + text)
+        elif tag in ("p", "div", "section", "header", "footer", "details", "summary"):
+            self._flush_para()
+        elif tag == "blockquote":
+            self._quote = False
+            self._flush_para()
+        elif tag in ("ul", "ol"):
+            self._list_depth = max(0, self._list_depth - 1)
+            self._flush_para()
+        elif tag in ("td", "th"):
+            self._in_cell = False
+            self._flush_cell()
+        elif tag == "tr":
+            if self._row_cells is not None:
+                cells = self._row_cells
+                self._row_cells = None
+                if cells:
+                    self.lines.append("| " + " | ".join(cells) + " |")
+                    if self._is_header_row:
+                        self.lines.append("|" + "---|" * len(cells))
+                        self._is_header_row = False
+        elif tag == "table":
+            self._flush_para()
+
+    def handle_data(self, data):
+        self._text(data)
+
+    def result(self) -> str:
+        self._flush_para()
+        out = []
+        prev_blank = True
+        for ln in self.lines:
+            if ln.strip():
+                out.append(ln)
+                prev_blank = False
+            else:
+                if not prev_blank:
+                    out.append("")
+                prev_blank = True
+        return "\n".join(out).strip() + "\n"
+
+
+def extract_article(html: str) -> tuple[str, str]:
+    """返回 (title, markdown)。title 取 <h1> 或 <title>。"""
+    m = re.search(r"<article[^>]*>(.*?)</article>", html, re.S | re.I)
+    body_html = m.group(1) if m else html
+    parser = ArticleToMarkdown()
+    parser.feed(body_html)
+    md = parser.result()
+    h1 = re.search(r"^#\s+(.+)$", md, re.M)
+    title = h1.group(1).strip() if h1 else ""
+    if not title:
+        t = re.search(r"<title>(.*?)</title>", html, re.S)
+        title = t.group(1).strip() if t else ""
+    return title, md
+
+
+def slug_of(path: str) -> str:
+    p = path[len("/docs/"):] if path.startswith("/docs/") else path
+    p = p.strip("/")
+    if not p:
+        p = "index"
+    return p
+
+
+def fetch(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": UA})
+    with urllib.request.urlopen(req, timeout=25) as resp:
+        return resp.read().decode("utf-8", errors="ignore")
+
+
+def main():
+    out_dir = Path(sys.argv[sys.argv.index("--out") + 1]) if "--out" in sys.argv \
+        else Path(__file__).resolve().parent.parent / "corpus"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # 1) URL 全集 = sitemap + EXTRA（按 unquote 后路径去重，中文与百分号编码视为同页）
+    sitemap_url = BASE + "/sitemap.xml"
+    xml = fetch(sitemap_url)
+    paths = [urlparse(u).path for u in re.findall(r"<loc>(.*?)</loc>", xml)
+             if "/docs/" in u]
+    paths += EXTRA_PATHS
+    # 归一化：unquote 去重，再统一以 / 结尾
+    norm = {}
+    for p in paths:
+        key = unquote(p).rstrip("/")
+        norm[key] = p if p.endswith("/") else p + "/"
+    paths = sorted(norm.values())
+    # sitemap 中的 articles/* 在 cn 站已 404（死链，指向另一域名的 SPA 兜底页），跳过
+    paths = [p for p in paths if "/docs/articles/" not in unquote(p)]
+
+    manifest = []
+    failed = []
+    for i, path in enumerate(paths, 1):
+        slug = slug_of(unquote(path))
+        # 统一 URL 编码（中文路径必须 quote，否则 ascii 编码错误）
+        url = BASE + quote(unquote(path), safe="/:")
+        try:
+            html = fetch(url)
+            title, md = extract_article(html)
+            if len(md.strip()) < 100:
+                raise ValueError(f"content too short: {len(md)} chars")
+            out_file = out_dir / f"{slug}.md"
+            out_file.parent.mkdir(parents=True, exist_ok=True)
+            out_file.write_text(md, encoding="utf-8")
+            chars = len(md)
+            manifest.append({
+                "slug": slug, "title": title, "url": url,
+                "chars": chars, "est_tokens": int(chars / 1.5),
+                "section": slug.split("/")[0] if "/" in slug else slug,
+            })
+            print(f"[{i}/{len(paths)}] {slug} ({chars} chars)")
+        except Exception as e:
+            failed.append({"slug": slug, "url": url, "error": str(e)})
+            print(f"[{i}/{len(paths)}] FAIL {slug}: {e}")
+        time.sleep(0.25)
+
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+    total_chars = sum(m["chars"] for m in manifest)
+    print(f"\nOK: {len(manifest)} pages, {total_chars} chars "
+          f"(~{total_chars // 1500}K est tokens); failed: {len(failed)}")
+    if failed:
+        (out_dir / "failed.json").write_text(
+            json.dumps(failed, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/rag-bench/scripts/run_g0.py
+++ b/rag-bench/scripts/run_g0.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""G0 基线：测量 CountBot 现状 BM25 文档级检索在 60 题问题集上的表现。
+
+口径：纯程序化打分（recall@k / MRR@10 / NDCG@10 / top1 / 注入 token 量），无 LLM 判分，可直接复现。
+指标：
+  - S1/S3（单文档）: recall@5/10, MRR@10, NDCG@10
+  - S2（跨文档）:   全源 recall@10, primary MRR@10, 平均源覆盖率
+  - S4（负样本）:   得分分布（top1 score），与非负样本对比
+  - token 注入（镜像生产 top_k=3, _handle_ask 整篇拼接）: est tokens 注入量
+est_tokens = chars / 1.5（CJK 近似）。
+"""
+import importlib.util
+import json
+import math
+import sys
+from pathlib import Path
+
+BENCH = Path(__file__).resolve().parent.parent          # rag-bench/
+REPO = Path(__file__).resolve().parents[2]              # 仓库根（含 backend/，从任意克隆位置可复现）
+INDEX_PY = REPO / "backend/modules/wiki/index.py"
+
+NO_JIEBA = "--no-jieba" in sys.argv  # 模拟生产默认环境（requirements.txt 中 jieba 被注释）
+
+# ---- 加载 worktree 的 BM25Index（不 import 整个 backend）----
+spec = importlib.util.spec_from_file_location("cb_bm25_index", INDEX_PY)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["cb_bm25_index"] = mod
+spec.loader.exec_module(mod)
+BM25Index = mod.BM25Index
+
+if NO_JIEBA:
+    # 强制走降级路径（单字分词）：_jieba 为 falsy 且非 None 时 _load_jieba 直接 return
+    BM25Index._jieba = False
+    assert BM25Index.tokenize("测试分词") == list("测试分词"), "no-jieba mode failed"
+
+# ---- 建索引：corpus manifest + md 文件 ----
+manifest = json.loads((BENCH / "corpus/manifest.json").read_text(encoding="utf-8"))
+index = BM25Index()
+docs = {}  # slug -> {title, content, chars, est_tokens}
+for entry in manifest:
+    slug = entry["slug"]
+    p = BENCH / "corpus" / f"{slug}.md"
+    content = p.read_text(encoding="utf-8")
+    docs[slug] = {
+        "title": entry["title"],
+        "content": content,
+        "chars": entry["chars"],
+        "est_tokens": entry["est_tokens"],
+    }
+    index.add_document(slug, entry["title"], content)
+
+print(f"[index] {len(docs)} docs loaded")
+
+questions = [json.loads(l) for l in (BENCH / "questions.jsonl").read_text(encoding="utf-8").splitlines() if l.strip()]
+print(f"[questions] {len(questions)} questions")
+
+# manifest slug 不含 .md 后缀（如 core/memory）；questions.jsonl 的 source_pages 带 .md，统一去掉
+def to_slug(page: str) -> str:
+    return page[:-3] if page.endswith(".md") else page
+
+for q in questions:
+    q["source_pages"] = [to_slug(p) for p in q["source_pages"]]
+
+TOP_K_EVAL = 10   # 评估口径
+TOP_K_PROD = 3    # 生产口径（wiki/tool.py _handle_ask）
+
+
+def est_tokens(text: str) -> int:
+    return int(len(text) / 1.5)
+
+
+def prod_injection(results) -> int:
+    """镜像生产行为：每个命中文档全文 `### {title}\\n{content}` 拼接进 prompt。"""
+    total = 0
+    for slug, _score in results:
+        d = docs.get(slug)
+        if d:
+            total += est_tokens(f"### {d['title']}\n{d['content']}")
+    return total
+
+
+def dcg(rels):
+    return sum(r / math.log2(i + 2) for i, r in enumerate(rels))
+
+
+detail = []
+agg = {
+    "single": {"n": 0, "rec5": 0, "rec10": 0, "mrr10": 0, "ndcg10": 0, "top1": 0},
+    "semantic": {"n": 0, "rec5": 0, "rec10": 0, "mrr10": 0, "ndcg10": 0, "top1": 0},
+    "needle": {"n": 0, "rec5": 0, "rec10": 0, "mrr10": 0, "ndcg10": 0, "top1": 0},
+    "cross": {"n": 0, "all_source_rec10": 0, "primary_mrr10": 0, "avg_coverage": 0.0,
+              "avg_sources": 0, "primary_top1": 0},
+    "negative": {"n": 0, "scores": [], "returned": 0},
+}
+
+for q in questions:
+    qid, qtype = q["id"], q["type"]
+    eval_results = index.search(q["question"], top_k=TOP_K_EVAL)
+    prod_results = index.search(q["question"], top_k=TOP_K_PROD)
+    eval_slugs = [s for s, _ in eval_results]
+
+    rec = {"id": qid, "type": qtype, "semantic": q["semantic"],
+           "question": q["question"], "expected_pages": q["source_pages"],
+           "top10": [{"slug": s, "score": round(sc, 3)} for s, sc in eval_results],
+           "prod_top3_slugs": [s for s, _ in prod_results],
+           "prod_injection_tokens": prod_injection(prod_results)}
+
+    if qtype in ("single_doc", "needle"):
+        src = q["source_pages"][0]
+        if src in eval_slugs:
+            rank = eval_slugs.index(src) + 1
+            rec["rank"] = rank
+            rec["hit"] = True
+        else:
+            rank = None
+            rec["hit"] = False
+        bucket = agg["semantic" if q["semantic"] else ("needle" if qtype == "needle" else "single")]
+        bucket["n"] += 1
+        if rank:
+            bucket["rec5"] += 1 if rank <= 5 else 0
+            bucket["rec10"] += 1
+            bucket["mrr10"] += 1.0 / rank
+            bucket["ndcg10"] += 1.0 / (1 + math.log2(rank))  # 单相关文档的二值 NDCG
+            bucket["top1"] += 1 if rank == 1 else 0
+
+    elif qtype == "cross_doc":
+        srcs = q["source_pages"]
+        hits = [s for s in srcs if s in eval_slugs]
+        primary = srcs[0]
+        p_rank = (eval_slugs.index(primary) + 1) if primary in eval_slugs else None
+        rec["hit_sources"] = hits
+        rec["missed_sources"] = [s for s in srcs if s not in hits]
+        rec["primary_rank"] = p_rank
+        b = agg["cross"]
+        b["n"] += 1
+        b["all_source_rec10"] += 1 if len(hits) == len(srcs) else 0
+        b["primary_mrr10"] += (1.0 / p_rank) if p_rank else 0.0
+        b["avg_coverage"] += len(hits) / len(srcs)
+        b["avg_sources"] += len(srcs)
+        b["primary_top1"] += 1 if p_rank == 1 else 0
+
+    elif qtype == "negative":
+        b = agg["negative"]
+        b["n"] += 1
+        top1_score = eval_results[0][1] if eval_results else 0.0
+        b["scores"].append(round(top1_score, 3))
+        b["returned"] += 1 if eval_results else 0
+        rec["top1_score"] = round(top1_score, 3)
+        rec["returned_any"] = bool(eval_results)
+
+    detail.append(rec)
+
+# ---- 负样本 vs 非负样本 top1 分数对比（S4 的核心观察）----
+nonneg_top1 = []
+for q, r in zip(questions, detail):
+    if q["type"] != "negative" and r["top10"]:
+        nonneg_top1.append(r["top10"][0]["score"])
+
+neg_scores = agg["negative"]["scores"]
+
+def stats(xs):
+    if not xs:
+        return {"n": 0}
+    xs2 = sorted(xs)
+    return {"n": len(xs), "mean": round(sum(xs)/len(xs), 2),
+            "median": round(xs2[len(xs2)//2], 2),
+            "min": round(xs2[0], 2), "max": round(xs2[-1], 2)}
+
+# S1/S3 生产 token 注入统计（正样本部分）
+inj_pos = [r["prod_injection_tokens"] for r in detail if r["type"] != "negative"]
+inj_neg = [r["prod_injection_tokens"] for r in detail if r["type"] == "negative"]
+
+summary = {}
+for k in ("single", "semantic", "needle"):
+    b = agg[k]
+    n = b["n"] or 1
+    summary[k] = {
+        "n": b["n"],
+        "recall@5": round(b["rec5"]/n, 3),
+        "recall@10": round(b["rec10"]/n, 3),
+        "MRR@10": round(b["mrr10"]/n, 3),
+        "NDCG@10": round(b["ndcg10"]/n, 3),
+        "top1_acc": round(b["top1"]/n, 3),
+    }
+b = agg["cross"]
+n = b["n"] or 1
+summary["cross"] = {
+    "n": b["n"],
+    "avg_sources_per_q": round(b["avg_sources"]/n, 2),
+    "all_source_recall@10": round(b["all_source_rec10"]/n, 3),
+    "primary_MRR@10": round(b["primary_mrr10"]/n, 3),
+    "primary_top1": round(b["primary_top1"]/n, 3),
+    "avg_source_coverage@10": round(b["avg_coverage"]/n, 3),
+}
+summary["negative"] = {
+    "n": agg["negative"]["n"],
+    "returned_any": agg["negative"]["returned"],
+    "top1_score_stats": stats(neg_scores),
+    "nonneg_top1_score_stats": stats(nonneg_top1),
+}
+summary["prod_injection"] = {
+    "note": "镜像 wiki/tool.py _handle_ask: top_k=3 整篇文档拼接, est_tokens=chars/1.5",
+    "positive_qs": stats(inj_pos),
+    "negative_qs": stats(inj_neg),
+    "corpus_total_est_tokens": sum(d["est_tokens"] for d in docs.values()),
+    "top3_injection_ratio_of_corpus": round((sum(inj_pos)/len(inj_pos)) / sum(d["est_tokens"] for d in docs.values()), 4) if inj_pos else None,
+}
+
+out = {"config": {"top_k_eval": TOP_K_EVAL, "top_k_prod": TOP_K_PROD,
+                  "docs": len(docs), "questions": len(questions), "no_jieba": NO_JIEBA},
+       "summary": summary, "detail": detail}
+(BENCH / "results").mkdir(exist_ok=True)
+suffix = "-nojieba" if NO_JIEBA else ""
+(BENCH / f"results/g0{suffix}-detail.json").write_text(json.dumps(out, ensure_ascii=False, indent=1), encoding="utf-8")
+print(json.dumps(summary, ensure_ascii=False, indent=1))
+
+# ---- 控制台快速诊断：未命中的题 ----
+print("\n== misses ==")
+for r in detail:
+    if r["type"] in ("single_doc", "needle") and not r["hit"]:
+        print(f"  MISS {r['id']}: {r['question'][:40]}... expected={r['expected_pages']}")
+    elif r["type"] == "cross_doc" and r.get("missed_sources"):
+        print(f"  PART {r['id']}: missed {r['missed_sources']}")

--- a/rag-bench/scripts/run_g1.py
+++ b/rag-bench/scripts/run_g1.py
@@ -1,0 +1,150 @@
+"""G1 实验：分块索引（本 PR）在同一批 60 题上与 G0 的 before/after 对比
+
+与 run_g0.py 同一把尺子（同题、同语料、同指标口径），仅检索单元不同：
+G0 = 文档级 BM25（整篇检索，改前），G1 = 分块级 BM25（backend/modules/rag，改后）。
+
+输出：results/g1-detail.json + 控制台对比摘要。
+"""
+
+import json
+import math
+import sys
+from pathlib import Path
+
+BENCH = Path(__file__).resolve().parent.parent
+REPO = Path(__file__).resolve().parents[2]              # 仓库根（含 backend/，从任意克隆位置可复现）
+
+sys.path.insert(0, str(REPO))
+
+from backend.modules.rag.stores import ChunkedBM25Index  # noqa: E402
+
+TOP_K_EVAL = 10      # 评估口径
+TOP_K_PROD = 6        # 生产镜像：ask 注入的块数（G0 生产是 top3 整篇）
+
+def est_tokens(text: str) -> int:
+    return int(len(text) / 1.5)
+
+def load_questions():
+    qs = [json.loads(l) for l in (BENCH / "questions.jsonl").read_text(encoding="utf-8").splitlines() if l.strip()]
+    for q in qs:
+        q["expected_pages"] = [p.replace(".md", "") for p in q["source_pages"]]
+    return qs
+
+def build_index():
+    store = ChunkedBM25Index()
+    manifest = json.load(open(BENCH / "corpus/manifest.json", encoding="utf-8"))
+    for e in manifest:
+        content = (BENCH / "corpus" / f"{e['slug']}.md").read_text(encoding="utf-8")
+        store.add_document(e["slug"], e["title"], content, [e.get("section", "")])
+    return store, len(manifest)
+
+def main():
+    questions = load_questions()
+    print(f"[questions] {len(questions)}")
+    store, n_docs = build_index()
+    n_chunks = store.stats()["total_chunks"]
+    print(f"[index] {n_docs} docs -> {n_chunks} chunks")
+
+    detail = []
+    for q in questions:
+        results = store.search_chunks(q["question"], top_k=TOP_K_EVAL)
+        top_slugs = [r["slug"] for r in results]
+
+        # 生产镜像：top6 块注入（口径与 G0 相同的 header+content）
+        prod = store.search_chunks(q["question"], top_k=TOP_K_PROD)
+        prod_injection = sum(est_tokens(f"### {r['doc_title']} › {r['section']}\n{r['content']}") for r in prod)
+        prod_slugs = [r["slug"] for r in prod]
+
+        rec = {
+            "id": q["id"],
+            "type": q["type"],
+            "semantic": q.get("semantic", False),
+            "question": q["question"],
+            "expected_pages": q["expected_pages"],
+            "top10": [{"chunk_id": r["chunk_id"], "slug": r["slug"], "score": r["score"]} for r in results],
+            "prod_top6_slugs": prod_slugs,
+            "prod_top6_chunks": [r["chunk_id"] for r in prod],
+            "prod_injection_tokens": prod_injection,
+        }
+
+        if q["type"] == "negative":
+            rec["top1_score"] = results[0]["score"] if results else 0.0
+        else:
+            exp = q["expected_pages"]
+            # 文档级命中（去重后按首次出现位置）
+            first_rank = None
+            for i, s in enumerate(top_slugs):
+                if s in exp:
+                    first_rank = i + 1
+                    break
+            rec["first_rank"] = first_rank
+            rec["hit"] = first_rank is not None
+            rec["all_source_hit"] = all(s in top_slugs for s in exp)
+            # 生产口径命中：期望文档出现在注入的 top6 块中
+            rec["prod_hit"] = any(s in prod_slugs for s in exp)
+            # 跨文档：生产覆盖的源比例
+            rec["prod_source_coverage"] = len([s for s in exp if s in prod_slugs]) / len(exp)
+        detail.append(rec)
+
+    # ---------- 汇总 ----------
+    def group(pred):
+        return [r for r in detail if pred(r)]
+
+    summary = {}
+    for name, rs in [
+        ("S1 直接", lambda: group(lambda r: r["type"] == "single_doc" and not r["semantic"])),
+        ("S1 语义", lambda: group(lambda r: r["type"] == "single_doc" and r["semantic"])),
+        ("S3 针", lambda: group(lambda r: r["type"] == "needle")),
+        ("S2 跨文档", lambda: group(lambda r: r["type"] == "cross_doc")),
+    ]:
+        rows = rs()
+        n = len(rows)
+        r5 = sum(1 for r in rows if r.get("first_rank") and r["first_rank"] <= 5)
+        r10 = sum(1 for r in rows if r.get("first_rank") and r["first_rank"] <= 10)
+        mrr = sum(1.0 / r["first_rank"] for r in rows if r.get("first_rank")) / n
+        top1 = sum(1 for r in rows if r.get("first_rank") == 1) / n
+        # NDCG@10（文档级，单相关文档：1/log2(rank+1)）
+        ndcg = sum(1.0 / math.log2(r["first_rank"] + 1) for r in rows if r.get("first_rank")) / n
+        inj = [r["prod_injection_tokens"] for r in rows]
+        prod_hit = sum(1 for r in rows if r.get("prod_hit"))
+        summary[name] = {
+            "n": n, "recall@5": r5 / n, "recall@10": r10 / n, "MRR@10": mrr,
+            "NDCG@10": ndcg, "top1": top1,
+            "prod_hit@6": prod_hit / n,
+            "prod_injection_mean": sum(inj) / n, "prod_injection_max": max(inj),
+        }
+        if name == "S2 跨文档":
+            summary[name]["all_source_hit@10"] = sum(1 for r in rows if r.get("all_source_hit")) / n
+            summary[name]["prod_source_coverage"] = sum(r["prod_source_coverage"] for r in rows) / n
+
+    neg = group(lambda r: r["type"] == "negative")
+    summary["S4 负样本"] = {
+        "n": len(neg),
+        "returned": sum(1 for r in neg if r["top10"]) / len(neg),
+        "prod_injection_mean": sum(r["prod_injection_tokens"] for r in neg) / len(neg),
+        "top1_score_max": max((r["top1_score"] for r in neg), default=0.0),
+    }
+
+    # 正样本总体注入（M1 验收：token 下降 >= 70%）
+    pos = [r for r in detail if r["type"] != "negative"]
+    summary["正样本总体"] = {
+        "n": len(pos),
+        "prod_injection_mean": sum(r["prod_injection_tokens"] for r in pos) / len(pos),
+        "prod_injection_max": max(r["prod_injection_tokens"] for r in pos),
+        "prod_hit@6": sum(1 for r in pos if r["prod_hit"]) / len(pos),
+    }
+
+    out = {"config": {"top_k_eval": TOP_K_EVAL, "top_k_prod": TOP_K_PROD,
+                      "docs": n_docs, "chunks": n_chunks, "questions": len(questions)},
+           "summary": summary, "detail": detail}
+    (BENCH / "results/g1-detail.json").write_text(json.dumps(out, ensure_ascii=False, indent=1), encoding="utf-8")
+
+    print("\n===== G1 分块索引摘要 =====")
+    for name, s in summary.items():
+        print(f"\n{name} (n={s['n']})")
+        for k, v in s.items():
+            if k != "n":
+                print(f"  {k}: {v:.3f}" if isinstance(v, float) else f"  {k}: {v}")
+
+if __name__ == "__main__":
+    main()

--- a/tests/rag/test_chunker.py
+++ b/tests/rag/test_chunker.py
@@ -1,0 +1,117 @@
+"""M1 分块检索单元测试：chunker + ChunkedBM25Index"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.modules.rag.chunker import HeadingChunker
+from backend.modules.rag.stores import ChunkedBM25Index
+
+
+SAMPLE = """# 部署指南
+
+介绍如何部署 CountBot。
+
+## 环境要求
+
+- Python 3.10+
+- Node.js 18+
+
+## Docker 部署
+
+使用 docker-compose 一键启动。
+
+```bash
+docker compose up -d
+```
+
+代码块内的 `#` 不应被识别为标题。
+
+## 数据库
+
+默认使用 SQLite，文件为 countbot.db。
+"""
+
+
+class TestHeadingChunker:
+    def test_sections_split_by_heading(self):
+        chunks = HeadingChunker().chunk("deploy", "部署", SAMPLE)
+        sections = [c.section for c in chunks]
+        assert any("环境要求" in s for s in sections)
+        assert any("Docker 部署" in s for s in sections)
+        assert any("数据库" in s for s in sections)
+
+    def test_heading_path_hierarchy(self):
+        chunks = HeadingChunker().chunk("deploy", "部署", SAMPLE)
+        docker = next(c for c in chunks if "Docker" in c.section)
+        assert docker.heading_path == "部署指南 > Docker 部署"
+
+    def test_chunk_id_traceable(self):
+        chunks = HeadingChunker().chunk("deploy", "部署", SAMPLE)
+        for c in chunks:
+            assert c.chunk_id.startswith("deploy#"), c.chunk_id
+
+    def test_fence_hash_not_heading(self):
+        chunks = HeadingChunker().chunk("deploy", "部署", SAMPLE)
+        docker = next(c for c in chunks if "Docker" in c.section)
+        assert "代码块内的" in docker.content
+        assert "docker compose up -d" in docker.content
+
+    def test_long_section_split_with_limit(self):
+        long_section = "## 长节\n\n" + "\n\n".join(f"段落 {i}。" + "内容" * 100 for i in range(30))
+        chunks = HeadingChunker(max_chars=1200).chunk("doc", "t", long_section)
+        assert len(chunks) > 1
+        assert all(len(c.content) <= 1400 for c in chunks)  # 上限 + 少量 overlap
+
+    def test_index_title_composition(self):
+        chunks = HeadingChunker().chunk("deploy", "部署指南", SAMPLE)
+        docker = next(c for c in chunks if "Docker" in c.section)
+        assert "部署指南" in docker.index_title
+        assert "Docker" in docker.index_title
+
+
+class TestChunkedBM25Index:
+    def _build(self):
+        store = ChunkedBM25Index()
+        store.add_document("deploy", "部署指南", SAMPLE, ["ops"])
+        store.add_document("memory", "记忆系统", "# 记忆\n\n记忆存在 memory.md 文件。\n", ["core"])
+        return store
+
+    def test_search_hits_section(self):
+        store = self._build()
+        results = store.search_chunks("Docker 部署", top_k=3)
+        assert results
+        assert results[0]["slug"] == "deploy"
+        assert "Docker" in results[0]["section"]
+
+    def test_result_traceability(self):
+        store = self._build()
+        for r in store.search_chunks("环境要求", top_k=5):
+            assert r["chunk_id"].startswith(("deploy#", "memory#"))
+
+    def test_remove_document(self):
+        store = self._build()
+        store.remove_document("deploy")
+        assert all(r["slug"] != "deploy" for r in store.search_chunks("Docker 部署", top_k=5))
+
+    def test_readd_updates_chunks(self):
+        store = self._build()
+        before = store.stats()["total_chunks"]
+        store.add_document("deploy", "部署指南", "# 部署\n\n只有一节。\n", ["ops"])
+        assert store.stats()["total_chunks"] < before
+        # 旧 Docker 内容必须已被替换（不再出现在任何块中）
+        for r in store.search_chunks("Docker 部署", top_k=5):
+            assert "docker compose" not in r["content"]
+
+    def test_persistence_roundtrip(self, tmp_path):
+        store = self._build()
+        f = tmp_path / "chunk_index.json"
+        store.save_to_file(str(f))
+        store2 = ChunkedBM25Index()
+        assert store2.load_from_file(str(f))
+        r = store2.search_chunks("Docker 部署", top_k=3)
+        assert r and r[0]["slug"] == "deploy"
+        assert store2.stats()["total_chunks"] == store.stats()["total_chunks"]

--- a/tests/rag/test_tool_switch.py
+++ b/tests/rag/test_tool_switch.py
@@ -1,0 +1,216 @@
+"""M1 开关回归测试：COUNTBOT_RAG_CHUNKS 未启用时与旧（文档级）行为一致
+
+这是"零行为变化"承诺的证据：
+1. 开关 OFF 时不实例化 RagService、不 import rag 模块（投毒验证）；
+2. OFF 路径的 search/ask 输出 = 纯文档级 BM25 结果（与直接调 WikiService 一致）；
+3. 开关 ON 时确实切换到块级路径（输出格式不同、含 [slug#section] 溯源）；
+4. RagService 依赖显式注入（构造签名）、on_document_added 只重建单文档。
+"""
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+import frontmatter
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.modules.wiki.service import WikiService
+from backend.modules.wiki.tool import WikiTool, _rag_chunks_enabled
+
+
+SAMPLE_DEPLOY = """介绍如何部署 CountBot。
+
+## Docker 部署
+
+使用 docker-compose 一键启动，命令为 docker compose up -d。
+"""
+
+SAMPLE_MEMORY = """记忆存储在 memory.md 文件中，按会话隔离。
+
+## 检索
+
+支持按关键词检索历史记忆。
+"""
+
+
+def write_concept(wiki_dir: Path, slug: str, title: str, content: str, tags=None):
+    """写入一篇带 frontmatter 的 wiki 文档（与 tool._handle_create 同构）"""
+    concepts = wiki_dir / "concepts"
+    concepts.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content)
+    post.metadata["title"] = title
+    post.metadata["tags"] = list(tags or [])
+    post.metadata["summary"] = content[:200].strip()
+    (concepts / f"{slug}.md").write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+@pytest.fixture
+def wiki_dir(tmp_path):
+    d = tmp_path / "wiki"
+    write_concept(d, "deploy", "部署指南", SAMPLE_DEPLOY, ["ops"])
+    write_concept(d, "memory", "记忆系统", SAMPLE_MEMORY, ["core"])
+    return d
+
+
+@pytest.fixture
+def no_rag_env(monkeypatch):
+    monkeypatch.delenv("COUNTBOT_RAG_CHUNKS", raising=False)
+
+
+@pytest.fixture
+def rag_env(monkeypatch):
+    monkeypatch.setenv("COUNTBOT_RAG_CHUNKS", "1")
+
+
+class TestFlagParsing:
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "On"])
+    def test_truthy(self, monkeypatch, value):
+        monkeypatch.setenv("COUNTBOT_RAG_CHUNKS", value)
+        assert _rag_chunks_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "garbage"])
+    def test_falsy(self, monkeypatch, value):
+        monkeypatch.setenv("COUNTBOT_RAG_CHUNKS", value)
+        assert _rag_chunks_enabled() is False
+
+    def test_unset_means_off(self, no_rag_env):
+        assert _rag_chunks_enabled() is False
+
+
+class TestSwitchOff:
+    """开关 OFF = 与旧文档级行为一致"""
+
+    def test_no_rag_instance_when_off(self, wiki_dir, no_rag_env):
+        tool = WikiTool(wiki_dir)
+        assert tool._rag is None
+
+    def test_off_search_matches_doc_level_service(self, wiki_dir, no_rag_env):
+        """OFF 的 search 输出必须是文档级 search_with_metadata 的纯格式化，
+        不掺入任何块级逻辑。"""
+        tool = WikiTool(wiki_dir)
+        # 独立构造一个无 RAG 知识的 WikiService 作参照（同目录、同索引）
+        reference = WikiService(wiki_dir)
+        expected = reference.search_with_metadata("Docker 部署", top_k=10, min_score_ratio=0.3)
+
+        out = tool._handle_search("Docker 部署", top_k=10)
+
+        assert expected, "参照检索不应为空"
+        assert out.startswith(f"Found {len(expected)} wiki entries for 'Docker 部署':")
+        for r in expected:
+            assert f"**{r['title']}**" in out
+            assert r["slug"] in out
+        # 块级格式的标志不应出现
+        assert "matching sections" not in out
+        assert "deploy#" not in out  # chunk_id 溯源标识，若出现说明走了块级
+
+    def test_off_path_survives_broken_rag_import(self, wiki_dir, no_rag_env, monkeypatch):
+        """投毒验证：rag 模块彻底损坏也不影响 OFF 路径（import 从未发生）"""
+        monkeypatch.setitem(sys.modules, "backend.modules.rag.service", None)
+        tool = WikiTool(wiki_dir)
+        assert tool._rag is None
+        out = tool._handle_search("Docker 部署", top_k=10)
+        assert "Docker" in out
+
+    def test_off_ask_falls_back_to_doc_level(self, wiki_dir, no_rag_env, monkeypatch):
+        """无 LLM provider 时，ask 走旧的文档级降级路径"""
+        fake_app = types.ModuleType("backend.app")
+        fake_app.get_shared_provider = lambda: None
+        monkeypatch.setitem(sys.modules, "backend.app", fake_app)
+
+        tool = WikiTool(wiki_dir)
+        out = asyncio.run(tool._handle_ask("如何用 Docker 部署"))
+        # 旧降级 = _format_search_results：文档标题 + 正文前 300 字
+        assert "部署指南" in out
+        assert "matching sections" not in out
+
+
+class TestSwitchOn:
+    """开关 ON = 切换到块级路径"""
+
+    def test_rag_instance_when_on(self, wiki_dir, rag_env):
+        tool = WikiTool(wiki_dir)
+        assert tool._rag is not None
+
+    def test_on_search_returns_sections(self, wiki_dir, rag_env):
+        tool = WikiTool(wiki_dir)
+        out = tool._handle_search("Docker 部署", top_k=10)
+        assert "matching sections" in out  # 块级格式
+        assert "deploy#" in out  # [slug#section] 溯源
+
+    def test_on_off_outputs_differ(self, wiki_dir, monkeypatch):
+        """同一个问题，两种开关必须产生不同粒度的输出（证明开关真的生效）"""
+        monkeypatch.delenv("COUNTBOT_RAG_CHUNKS", raising=False)
+        off_tool = WikiTool(wiki_dir)
+        monkeypatch.setenv("COUNTBOT_RAG_CHUNKS", "1")
+        on_tool = WikiTool(wiki_dir)
+
+        off_out = off_tool._handle_search("Docker 部署", top_k=10)
+        on_out = on_tool._handle_search("Docker 部署", top_k=10)
+
+        assert "wiki entries" in off_out  # 文档级
+        assert "matching sections" in on_out  # 块级
+
+    def test_on_ask_falls_back_to_chunk_search(self, wiki_dir, rag_env, monkeypatch):
+        fake_app = types.ModuleType("backend.app")
+        fake_app.get_shared_provider = lambda: None
+        monkeypatch.setitem(sys.modules, "backend.app", fake_app)
+
+        tool = WikiTool(wiki_dir)
+        out = asyncio.run(tool._handle_ask("如何用 Docker 部署"))
+        assert "matching sections" in out
+
+
+class TestRagServiceInternals:
+    """RagService：显式依赖注入 + 单文档重建"""
+
+    def test_explicit_wiki_dir_dependency(self, wiki_dir):
+        """构造签名要求显式 wiki_dir（不读 WikiService 私有属性）"""
+        from backend.modules.rag.service import RagService
+
+        svc = WikiService(wiki_dir)
+        rag = RagService(svc, wiki_dir)
+        assert rag.stats()["total_docs"] == 2
+
+    def test_on_document_added_rebuilds_single_doc(self, wiki_dir):
+        """新增文档只重建该文档的块，不动其他文档的索引"""
+        from backend.modules.rag.service import RagService
+
+        svc = WikiService(wiki_dir)
+        rag = RagService(svc, wiki_dir)
+        before = rag.stats()
+
+        # 模拟 tool 的 create 流程：先写文件，再通知 RAG
+        write_concept(wiki_dir, "newdoc", "新条目", "# 新\n\n云原生部署新方案。\n", ["new"])
+        n = rag.on_document_added("newdoc")
+
+        assert n >= 1
+        assert rag._store.has_document("newdoc")
+        # 旧文档的块原样保留
+        assert rag._store.has_document("deploy")
+        assert rag._store.has_document("memory")
+        stats = rag.stats()
+        assert stats["total_docs"] == before["total_docs"] + 1
+        assert stats["total_chunks"] > before["total_chunks"]
+        # 新内容可检索
+        assert any(r["slug"] == "newdoc" for r in rag.search_chunks("云原生"))
+
+    def test_on_document_added_replaces_old_chunks(self, wiki_dir):
+        """更新文档时旧块被替换（不残留旧内容）"""
+        from backend.modules.rag.service import RagService
+
+        svc = WikiService(wiki_dir)
+        rag = RagService(svc, wiki_dir)
+        assert any("docker-compose" in r["content"]
+                   for r in rag.search_chunks("docker-compose 一键启动"))
+
+        # 模拟 tool 的 update 流程：改文件 → service.add_document（失效缓存）→ 通知 RAG
+        write_concept(wiki_dir, "deploy", "部署指南", "部署方式已改为 k8s helm install。\n", ["ops"])
+        svc.add_document("deploy", "部署指南", "部署方式已改为 k8s helm install。\n", ["ops"])
+        rag.on_document_added("deploy")
+
+        assert all("docker-compose" not in r["content"]
+                   for r in rag.search_chunks("docker-compose 一键启动"))
+        assert any("helm" in r["content"] for r in rag.search_chunks("k8s helm"))

--- a/tests/rag/test_tool_switch.py
+++ b/tests/rag/test_tool_switch.py
@@ -214,3 +214,164 @@ class TestRagServiceInternals:
         assert all("docker-compose" not in r["content"]
                    for r in rag.search_chunks("docker-compose 一键启动"))
         assert any("helm" in r["content"] for r in rag.search_chunks("k8s helm"))
+
+
+class ScriptedProvider:
+    """按调用顺序返回预设响应的假 LLM provider；Exception 实例则抛出"""
+
+    def __init__(self, replies):
+        self.replies = list(replies)
+        self.calls = []
+
+    async def chat_completion(self, prompt, **kwargs):
+        self.calls.append(prompt)
+        if not self.replies:
+            return "DEFAULT"
+        reply = self.replies.pop(0)
+        if isinstance(reply, Exception):
+            raise reply
+        return reply
+
+
+def _install_provider(monkeypatch, provider):
+    fake_app = types.ModuleType("backend.app")
+    fake_app.get_shared_provider = lambda: provider
+    monkeypatch.setitem(sys.modules, "backend.app", fake_app)
+
+
+GRADING_MARK = "检索质量评估器"
+REWRITE_MARK = "改写成更适合知识库关键词检索"
+GEN_MARK = "请根据以下 Wiki 知识库内容回答问题"
+
+
+class TestRagAskGrading:
+    """块级问答的评估-路由（CRAG）行为：三段路由 + 拒答 + 全链路回退"""
+
+    def test_grade_all_generates_directly(self, wiki_dir, rag_env, monkeypatch):
+        provider = ScriptedProvider([
+            '{"grade": "all", "relevant": [1, 2]}',
+            "ANSWER_OK",
+        ])
+        _install_provider(monkeypatch, provider)
+        tool = WikiTool(wiki_dir)
+
+        out = asyncio.run(tool._handle_ask("如何用 Docker 部署"))
+
+        assert out == "ANSWER_OK"
+        assert len(provider.calls) == 2  # 评估 1 次 + 生成 1 次，无改写
+        assert GRADING_MARK in provider.calls[0]
+        assert GEN_MARK in provider.calls[1]
+        assert "docker-compose" in provider.calls[1]  # 生成上下文含检索块
+
+    def test_grade_partial_filters_unrelated_chunks(self, wiki_dir, rag_env, monkeypatch):
+        provider = ScriptedProvider([
+            '{"grade": "partial", "relevant": [1]}',
+            "ANSWER_OK",
+        ])
+        _install_provider(monkeypatch, provider)
+        tool = WikiTool(wiki_dir)
+
+        out = asyncio.run(tool._handle_ask("如何用 Docker 部署"))
+
+        assert out == "ANSWER_OK"
+        gen_prompt = provider.calls[1]
+        # 只注入编号 1 的块：无关文档（memory）不得进入生成上下文
+        assert "memory.md" not in gen_prompt
+        assert "检索" not in gen_prompt.split("问题")[0] or "Docker" in gen_prompt
+
+    def test_grade_none_refuses_after_one_rewrite(self, wiki_dir, rag_env, monkeypatch):
+        provider = ScriptedProvider([
+            '{"grade": "none", "relevant": []}',   # 首次评估：全不相关
+            "Docker 部署方法",                       # 改写
+            '{"grade": "none", "relevant": []}',   # 重试评估：仍不相关
+        ])
+        _install_provider(monkeypatch, provider)
+        tool = WikiTool(wiki_dir)
+
+        out = asyncio.run(tool._handle_ask("如何用 Docker 部署"))
+
+        assert "没有找到" in out
+        # 评估 2 次 + 改写 1 次，绝不发起生成
+        assert len(provider.calls) == 3
+        assert not any(GEN_MARK in c for c in provider.calls)
+
+    def test_grade_none_retry_then_succeeds(self, wiki_dir, rag_env, monkeypatch):
+        provider = ScriptedProvider([
+            '{"grade": "none", "relevant": []}',   # 首次评估：不相关
+            "docker compose 部署",                   # 改写
+            '{"grade": "all", "relevant": [1]}',   # 重试评估：相关
+            "ANSWER_AFTER_RETRY",
+        ])
+        _install_provider(monkeypatch, provider)
+        tool = WikiTool(wiki_dir)
+
+        out = asyncio.run(tool._handle_ask("如何用 Docker 部署"))
+
+        assert out == "ANSWER_AFTER_RETRY"
+        assert len(provider.calls) == 4
+
+    def test_grading_failure_falls_back_to_generation(self, wiki_dir, rag_env, monkeypatch):
+        provider = ScriptedProvider([
+            RuntimeError("grading exploded"),  # 评估失败 → 回退旧行为：直接生成
+            "ANSWER_FALLBACK",
+        ])
+        _install_provider(monkeypatch, provider)
+        tool = WikiTool(wiki_dir)
+
+        out = asyncio.run(tool._handle_ask("如何用 Docker 部署"))
+
+        assert out == "ANSWER_FALLBACK"
+        assert len(provider.calls) == 2
+
+    def test_unparseable_grade_falls_back(self, wiki_dir, rag_env, monkeypatch):
+        provider = ScriptedProvider([
+            "我觉得这些结果看起来都挺好的！",  # 非 JSON → 评估不可用
+            "ANSWER_UNPARSED",
+        ])
+        _install_provider(monkeypatch, provider)
+        tool = WikiTool(wiki_dir)
+
+        out = asyncio.run(tool._handle_ask("如何用 Docker 部署"))
+        assert out == "ANSWER_UNPARSED"
+        assert len(provider.calls) == 2
+
+    def test_no_provider_keeps_legacy_fallback(self, wiki_dir, rag_env, monkeypatch):
+        """无 provider：评估/改写/生成全部跳过，回退块级搜索（与旧行为一致）"""
+        provider = ScriptedProvider([])
+        _install_provider(monkeypatch, None)
+        tool = WikiTool(wiki_dir)
+
+        out = asyncio.run(tool._handle_ask("如何用 Docker 部署"))
+        assert "matching sections" in out
+        assert len(provider.calls) == 0
+
+
+class TestParseGrade:
+    """_parse_grade：LLM 输出 → (grade, relevant_ids) 的解析契约"""
+
+    @pytest.mark.parametrize("text,grade,rel", [
+        ('{"grade": "all", "relevant": [1, 2]}', "all", [1, 2]),
+        ('好的，这是我的判断：\n{"grade": "partial", "relevant": [2]}', "partial", [2]),
+        ('{"grade": "NONE", "relevant": []}', "none", []),
+        ('{"grade": "none"}', "none", []),
+    ])
+    def test_valid(self, text, grade, rel):
+        assert WikiTool._parse_grade(text, 6) == (grade, rel)
+
+    @pytest.mark.parametrize("text", [
+        "",
+        "完全没有 JSON",
+        '{"grade": "maybe"}',
+        '{"grade": "partial", "relevant": "not-a-list"}',  # relevant 非列表 → 空编号
+    ])
+    def test_invalid_returns_none(self, text):
+        if "not-a-list" in text:
+            grade, rel = WikiTool._parse_grade(text, 6)
+            assert grade == "partial" and rel == []
+        else:
+            assert WikiTool._parse_grade(text, 6) == (None, None)
+
+    def test_out_of_range_ids_dropped(self):
+        grade, rel = WikiTool._parse_grade('{"grade": "partial", "relevant": [0, 1, 9, "2"]}', 6)
+        assert grade == "partial"
+        assert rel == [1, 2]


### PR DESCRIPTION
Closes #112（改动 2：评估路由与诚实拒答）。基于 #109（请先合并 #109，合并后本 PR 的 diff 会自动收敛为纯增量）。

## 问题

#109 的块级问答把 top-6 块无条件注入生成——知识库中**没有答案的问题也照样回答**：负样本实测 10/10 全部硬答，且这类问题注入的无关上下文反而更多（平均 13,616 est tokens），是在无依据上下文上编答案。

而且这个问题**无法用规则解决**（两组实测，详见 #112）：
- BM25 分数不可分：负样本 top1 分数与正样本重叠 7/10；
- 词重叠信号也不可分：负样本最高词重叠 0.60，35/50 正样本低于它。

## 改动（约 130 行 + 12 个测试）

`wiki/tool.py` 的 `_rag_ask` 改为"检索 → LLM 评估 → 三段路由"：

1. **评估**：检索后一次轻量 LLM 调用（约 200-400 token），判断块与问题的相关性（all / partial / none，输出约束为可解析 JSON）；
2. **路由**：全相关 → 正常生成；部分相关 → 过滤到相关块再生成；全不相关 → **LLM 改写问题重检索一次**，仍不相关 → 明确拒答；
3. **兜底**：无 provider / 评估调用失败 / 输出不可解析 → 回退到 #109 的原行为（全部注入直接生成），零破坏。

评估器采用"拿不准优先 partial"的保守倾向——实测该措辞把命中正样本的误拒从 5/41 压到 1/41，同时负样本拒答保持 10/10。

## 端到端实测（DeepSeek API，#107 同一批 60 题）

| 组 | #109（改前） | 本 PR |
|---|---|---|
| 负样本（知识库无答案）拒答 | 0/10（全部硬答） | **10/10** |
| 检索命中的正样本正常回答 | 41/41 | **40/41（98%）** |
| 检索未命中正样本：改写重试后获得带引用回答 | 0/9 | **5/9**（另 3 题拒答、1 题无引用） |
| 回答带 [slug#section] 引用 | — | 31/40 |

如实说明的两点：
- 1/41 误拒（S3-04 "LRU 缓存容量是多少"）：超精确数字题，检索命中的块确实不含该数字，拒答 arguably 正确；
- 改写重试的额外收益：5 个原本检索未命中的口语化题（如"下次想起我说过的话"→记忆机制）经改写重检索后拿到带引用的正确回答——部分缓解了原本认为只有向量检索才能解决的语义鸿沟场景。

## 兼容性

- 仅 `COUNTBOT_RAG_CHUNKS=1` 路径生效，不新增环境变量、零新依赖
- 评估/改写复用现有 `get_shared_provider` 通道；每次问答增加 1-2 次轻量 LLM 调用（约 200-400 token/次），仅开关开启时发生
- 开关关闭或评估不可用时行为与 #109 完全一致（有专项回归测试）

## 测试

```bash
pytest tests/ -q   # 138 passed（含 12 个新增：三段路由、拒答、改写重试成功、
                   # 评估失败/不可解析/无 provider 三种回退、评估输出解析契约）
```

Refs: #112, #107
