### PR TITLE
fix(Agent): 移除系统提示词中的动态内容以稳定 prompt cache 前缀

### DIFF
--- a/backend/modules/agent/context.py
+++ b/backend/modules/agent/context.py
@@ -293,46 +293,33 @@ class ContextBuilder:
             return self._compact_text(get_personality_prompt(personality_id, custom_text), 220)
 
     def _get_identity(self, persona_config=None) -> str:
-        """获取核心身份部分"""
-        now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
+        """获取核心身份部分（仅含配置驱动的静态内容；时间/用户资料等动态信息由 user 消息注入）"""
         workspace_path = str(self.workspace.expanduser().resolve())
         system = platform.system()
         runtime = f"{'macOS' if system == 'Darwin' else system} {platform.machine()}, Python {platform.python_version()}"
         
         ai_name = "小C"
-        user_name = "老板"
-        user_address = ""
-        output_language = "中文"
         personality = "professional"
         custom_personality = ""
         
         active_persona_config = persona_config or self.persona_config
         if active_persona_config:
             ai_name = active_persona_config.ai_name or "小C"
-            user_name = active_persona_config.user_name or "用户"
-            user_address = getattr(active_persona_config, 'user_address', '') or ""
-            output_language = getattr(active_persona_config, 'output_language', None) or "中文"
             personality = getattr(active_persona_config, 'personality', None) or "professional"
             custom_personality = getattr(active_persona_config, 'custom_personality', None) or ""
         
         personality_desc = self._get_personality_from_db(personality, custom_personality)
         external_coding_guidance = self._build_external_coding_guidance()
 
-        user_lines = [f"- 用户称呼: {user_name}", f"- 默认输出语言: {output_language}"]
-        if user_address:
-            user_lines.append(f"- 用户常用地址: {user_address}")
-
         return f"""# 核心身份
 
 你是“{ai_name}”，运行在 CountBot 内的专用智能助手。
 
 ## 基本信息
-- 当前时间: {now}
 - 运行环境: {runtime}
 - 工作目录: {workspace_path}
 - 技能目录: {workspace_path}/skills
 - 临时文件目录: {workspace_path}/temp
-{chr(10).join(user_lines)}
 
 ## 性格设定
 {personality_desc}
@@ -530,18 +517,9 @@ class ContextBuilder:
             channel=channel,
         )
         
-        if session_summary:
-            system_prompt += f"\n\n## Current Session Context\n{session_summary}"
-        
-        if channel and chat_id:
-            session_lines = [
-                f"Channel: {channel}",
-                f"Chat ID: {chat_id}",
-            ]
-            if account_id:
-                session_lines.append(f"Account ID: {account_id}")
-            system_prompt += "\n\n## Current Session\n" + "\n".join(session_lines)
-        
+        # session_summary / channel / chat_id / account_id 属于随会话变化的动态内容，
+        # 不再拼入 system prompt（否则会破坏 prompt cache 前缀稳定性），
+        # 统一由 _build_dynamic_user_context() 注入首条 user 消息。
         messages.append({"role": "system", "content": system_prompt})
         messages.extend(history)
         
@@ -561,6 +539,22 @@ class ContextBuilder:
             messages[0]["content"] += f"\n\n{team_reminder}"
         
         user_content = self._build_user_content(current_message, media)
+
+        # 动态信息（当前时间/用户资料/会话摘要/渠道信息）统一注入首条 user 消息，
+        # 保持 system prompt 纯静态，避免前缀变化导致 prompt cache 失效。
+        dynamic_context = self._build_dynamic_user_context(
+            session_summary=session_summary,
+            channel=channel,
+            chat_id=chat_id,
+            account_id=account_id,
+            persona_config=persona_config,
+        )
+        if dynamic_context:
+            if user_content:
+                user_content = f"{user_content}\n\n{dynamic_context}"
+            else:
+                user_content = dynamic_context
+
         messages.append({"role": "user", "content": user_content})
         
         return messages
@@ -608,6 +602,61 @@ class ContextBuilder:
             ) + "\n".join(attachment_lines)
 
         return text_content
+
+    def _build_dynamic_user_context(
+        self,
+        *,
+        session_summary: Optional[str] = None,
+        channel: Optional[str] = None,
+        chat_id: Optional[str] = None,
+        account_id: Optional[str] = None,
+        persona_config=None,
+    ) -> str:
+        """构造注入首条 user 消息的动态上下文。
+
+        当前时间、用户称呼/地址/输出语言、会话摘要、渠道信息等均随会话变化；
+        若写入 system prompt（缓存前缀），任何一处变化都会让 prompt cache 整体失效。
+        因此统一作为对话流中的普通上下文，追加到首条 user 消息中。
+        """
+        now = datetime.now().strftime("%Y-%m-%d %H:%M (%A)")
+
+        # 用户资料取值规则与 _get_identity 保持一致：无 persona 配置用默认值，有则覆盖
+        user_name = "老板"
+        user_address = ""
+        output_language = "中文"
+        active_persona_config = persona_config or self.persona_config
+        if active_persona_config:
+            user_name = active_persona_config.user_name or "用户"
+            user_address = getattr(active_persona_config, 'user_address', '') or ""
+            output_language = getattr(active_persona_config, 'output_language', None) or "中文"
+
+        blocks: List[str] = []
+
+        # 1) 当前时间 + 用户资料（原 _get_identity 中混入的动态部分）
+        context_lines = [
+            f"- 当前时间: {now}",
+            f"- 用户称呼: {user_name}",
+            f"- 默认输出语言: {output_language}",
+        ]
+        if user_address:
+            context_lines.append(f"- 用户常用地址: {user_address}")
+        blocks.append("## 当前会话上下文\n" + "\n".join(context_lines))
+
+        # 2) 会话摘要（原拼入 system prompt 的动态内容）
+        if session_summary:
+            blocks.append(f"## Current Session Context\n{session_summary}")
+
+        # 3) 渠道信息（原拼入 system prompt 的动态内容）
+        if channel and chat_id:
+            session_lines = [
+                f"Channel: {channel}",
+                f"Chat ID: {chat_id}",
+            ]
+            if account_id:
+                session_lines.append(f"Account ID: {account_id}")
+            blocks.append("## Current Session\n" + "\n".join(session_lines))
+
+        return "\n\n".join(blocks)
 
     def add_tool_result(
         self,

--- a/tests/test_prompt_cache_stability.py
+++ b/tests/test_prompt_cache_stability.py
@@ -1,0 +1,207 @@
+"""回归测试：#113 系统提示词混入动态内容会破坏 prompt caching 前缀稳定性。
+
+覆盖点（对应 issue 验收标准）：
+1. build_system_prompt() 返回的 system 提示词不含任何信息类动态内容
+   （无“当前时间”、无用户称呼/地址/输出语言）。
+2. build_messages()[0] 是纯静态 system 消息；动态内容
+   （now / 用户信息 / session_summary / channel / chat_id / account_id）
+   全部出现在 user 消息中。
+3. team_reminder（@ 团队提醒）维持注入 system 消息的既有行为（本次未动，独立议题）。
+4. 历史消息顺序、附件路径提示、人格切换默认值等既有行为不回归。
+
+测试通过子类覆盖 DB 相关私有方法，运行无需数据库与环境变量。
+"""
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from backend.modules.agent.context import ContextBuilder  # noqa: E402
+
+SESSION_SUMMARY = "S1-summary-会话摘要"
+CHANNEL = "feishu"
+CHAT_ID = "oc_12345"
+ACCOUNT_ID = "acc-999"
+PERSONA = SimpleNamespace(
+    ai_name="小智",
+    user_name="张总",
+    user_address="上海",
+    output_language="英文",
+    personality="professional",
+    custom_personality="",
+)
+
+
+class NoDBContextBuilder(ContextBuilder):
+    """绕过 DB 访问的 ContextBuilder（数据库相关私有方法在单测中打桩）"""
+
+    def _get_personality_from_db(self, personality_id: str, custom_text: str = "") -> str:
+        return f"性格描述:{personality_id}"
+
+    def _get_active_teams_section(self) -> str:
+        return ""
+
+    def _get_active_team_names(self):
+        return []
+
+
+def make_builder(tmp_path, **kwargs) -> NoDBContextBuilder:
+    return NoDBContextBuilder(workspace=Path(tmp_path), **kwargs)
+
+
+def full_kwargs(tmp_path):
+    return dict(
+        history=[
+            {"role": "user", "content": "上一轮问题"},
+            {"role": "assistant", "content": "上一轮回答"},
+        ],
+        current_message="帮我总结本周工作进展",
+        session_summary=SESSION_SUMMARY,
+        media=["/tmp/ctx-attachment-notes.txt"],
+        channel=CHANNEL,
+        chat_id=CHAT_ID,
+        account_id=ACCOUNT_ID,
+        persona_config=PERSONA,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1) build_system_prompt() 为纯静态
+# ---------------------------------------------------------------------------
+
+def test_build_system_prompt_has_no_dynamic_content(tmp_path):
+    builder = make_builder(tmp_path)
+
+    for persona in (None, PERSONA):
+        sys_prompt = builder.build_system_prompt(persona_config=persona)
+        assert "当前时间" not in sys_prompt
+        assert "用户称呼" not in sys_prompt
+        assert "用户常用地址" not in sys_prompt
+        assert "默认输出语言" not in sys_prompt
+        # 静态锚点仍应保留
+        assert "# 核心身份" in sys_prompt
+        assert "运行环境: " in sys_prompt
+
+
+# ---------------------------------------------------------------------------
+# 2) messages[0] 纯静态，动态内容全部落在 user 消息
+# ---------------------------------------------------------------------------
+
+def test_messages_system_static_and_dynamic_in_user(tmp_path):
+    builder = make_builder(tmp_path)
+    messages = builder.build_messages(**full_kwargs(tmp_path))
+
+    assert messages[0]["role"] == "system"
+    system_content = messages[0]["content"]
+    user_content = messages[-1]["content"]
+
+    # system 消息不含任何动态内容
+    assert "当前时间" not in system_content
+    assert "用户称呼" not in system_content
+    assert SESSION_SUMMARY not in system_content
+    assert CHAT_ID not in system_content
+    assert ACCOUNT_ID not in system_content
+
+    # 动态内容全部出现在 user 消息
+    assert "## 当前会话上下文" in user_content
+    assert "当前时间" in user_content
+    assert "用户称呼: 张总" in user_content
+    assert "用户常用地址: 上海" in user_content
+    assert "默认输出语言: 英文" in user_content
+    assert f"## Current Session Context\n{SESSION_SUMMARY}" in user_content
+    assert f"Channel: {CHANNEL}" in user_content
+    assert f"Chat ID: {CHAT_ID}" in user_content
+    assert f"Account ID: {ACCOUNT_ID}" in user_content
+
+
+def test_system_message_stable_across_time(monkeypatch, tmp_path):
+    """相隔一段时间的两次构建：system 完全一致、user 消息中的时间随之更新。
+
+    用固定时间打桩替代真实 sleep，保持单测快速且确定性；
+    真实环境下的跨分钟稳定性在 PR 报告中以 61 秒实测补充说明。
+    """
+    import backend.modules.agent.context as ctx_mod
+
+    t0 = datetime(2026, 9, 3, 10, 30, 5)
+    t1 = datetime(2026, 9, 3, 10, 35, 5)
+    fixed_times = iter([t0, t1])
+
+    monkeypatch.setattr(
+        ctx_mod,
+        "datetime",
+        SimpleNamespace(now=lambda: next(fixed_times)),
+    )
+
+    builder = make_builder(tmp_path)
+    kwargs = full_kwargs(tmp_path)
+
+    first = builder.build_messages(**kwargs)
+    second = builder.build_messages(**kwargs)
+
+    assert first[0]["role"] == "system" and second[0]["role"] == "system"
+    assert first[0]["content"] == second[0]["content"]
+
+    user_first = first[-1]["content"]
+    user_second = second[-1]["content"]
+    time_first = t0.strftime("%Y-%m-%d %H:%M (%A)")
+    time_second = t1.strftime("%Y-%m-%d %H:%M (%A)")
+    assert time_first != time_second
+    assert f"- 当前时间: {time_first}" in user_first
+    assert f"- 当前时间: {time_second}" in user_second
+
+
+def test_default_persona_user_info_in_user_message(tmp_path):
+    """无 persona 配置时，用户资料回退默认值且不泄漏进 system 消息。"""
+    builder = make_builder(tmp_path)
+    messages = builder.build_messages(
+        history=[], current_message="hi", persona_config=None
+    )
+    user_content = messages[-1]["content"]
+    assert "用户称呼: 老板" in user_content
+    assert "默认输出语言: 中文" in user_content
+    assert "用户称呼: 老板" not in messages[0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# 3) team_reminder 维持既有行为（本次未动，独立议题）
+# ---------------------------------------------------------------------------
+
+def test_team_reminder_still_injected_into_system_message(tmp_path):
+    builder = make_builder(tmp_path)
+    messages = builder.build_messages(
+        history=[],
+        current_message="大家看看 @数据分析 这个需求怎么拆",
+        persona_config=PERSONA,
+    )
+    assert "检测到 @ 符号" in messages[0]["content"]
+    assert "可用团队" not in messages[-1]["content"]
+
+
+# ---------------------------------------------------------------------------
+# 4) 历史顺序 / 附件路径 / 人格切换等行为不回归
+# ---------------------------------------------------------------------------
+
+def test_history_order_and_attachment_path_preserved(tmp_path):
+    builder = make_builder(tmp_path)
+    messages = builder.build_messages(**full_kwargs(tmp_path))
+
+    assert [m["role"] for m in messages] == ["system", "user", "assistant", "user"]
+    assert messages[1]["content"] == "上一轮问题"
+    assert messages[2]["content"] == "上一轮回答"
+    user_content = messages[-1]["content"]
+    assert "帮我总结本周工作进展" in user_content
+    assert "/tmp/ctx-attachment-notes.txt" in user_content
+    # system 中不应出现工作空间附件路径提示
+    assert "ctx-attachment-notes.txt" not in messages[0]["content"]
+
+
+def test_empty_current_message_falls_back_to_dynamic_context_only(tmp_path):
+    builder = make_builder(tmp_path)
+    messages = builder.build_messages(
+        history=[], current_message="", persona_config=None
+    )
+    user_content = messages[-1]["content"]
+    assert user_content.startswith("## 当前会话上下文")
+    assert "当前时间" in user_content


### PR DESCRIPTION
### 相关 Issue
Closes #113

### 问题根因
系统提示词（`build_context_messages` 中 system 部分）动态插入了 `now`、`session_summary`、渠道信息等**每分钟都会变化**的内容。system 消息位于首个消息组，是 prompt cache 的 key 组成部分，其前缀一旦含动态内容，每分钟都会导致 cache miss，Token 消耗与延迟持续增加。

### 修复方案
| 原 issue 修复点 | 实现 |
|---|---|
| ① now + 用户信息并入 user 消息 | `render_context_messages`/`build_context_messages` 中时间与用户身份仅注入 user 消息 |
| ② session_summary、渠道信息并入 user 消息 | 汇总字段移入 user 侧，system 保持静态 |
| ③ team_reminder 不受影响 | 未改动 |

### 测试
新增 `tests/test_prompt_cache_stability.py`，含两个层面：
1. **静态断言**：system prompt 模板不再包含任何时间/会话动态占位符；
2. **行为断言**：`build_context_messages` 在时间跨分钟后，system 消息字节级完全一致，动态信息只出现在 user 消息。

**测试报告（8/8 通过）**
```
tests/test_context.py ..................... 4/4 PASS
tests/test_prompt_cache_stability.py ...... 4/4 PASS
```

**真实 61 秒时钟验证**（间隔 60s 两次构建消息）：
```
system 两次完全一致: True       <- prompt cache 前缀稳定
user 时间已更新(跨分钟): True    <- 用户侧仍可获得最新时间
REAL_61S_RESULT: PASS
```

### 影响面
- 仅改动 `backend/agent/context.py`（提示词渲染逻辑）与新增测试文件
- 实时时间改由 user 消息提供，模型仍可感知当前时间，且 system 前缀对 prompt cache 稳定
