### PR TITLE
fix(Agent): 工具调用失败隔离——主循环超时/取消状态/重试生效/统一失败文案

### DIFF
--- a/backend/modules/agent/loop.py
+++ b/backend/modules/agent/loop.py
@@ -10,6 +10,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 
 from loguru import logger
 from backend.modules.tools.conversation_history import get_conversation_history
+from backend.modules.tools._failure import RetryableToolError
 
 
 def _is_key_rotation_eligible_error(error_text: str) -> bool:
@@ -32,6 +33,12 @@ class AgentLoop:
     """Agent 主循环类 - 处理消息、调用 LLM、执行工具、生成响应"""
 
     MAX_KEY_ROTATION_RETRIES = 3
+
+    # 自管闹钟的长任务工具：内部自带超时等待与超时返回文案
+    # （spawn 等子代理至 subagent_timeout；workflow_run 驱动多子代理；
+    #  external_coding_agent 按 profile timeout 运行），
+    # 主循环外层 wait_for 对其豁免，避免被默认短超时误杀长任务。
+    _SELF_ALARMING_TOOLS = frozenset({"spawn", "workflow_run", "external_coding_agent"})
 
     def __init__(
         self,
@@ -76,6 +83,21 @@ class AgentLoop:
             tool_name = str(getattr(tool_call, "name", "") or "").strip() or "<unknown>"
             parts.append(f"{tool_name}#{tool_id}")
         return ", ".join(parts) if parts else "<none>"
+
+    def _resolve_tool_timeout_seconds(self) -> int:
+        """解析主循环工具调用超时（秒）。
+
+        来自 config.agent.tool_timeout_seconds，默认 60；解析失败时兜底默认值。
+        """
+        try:
+            from backend.modules.config.loader import config_loader
+
+            return config_loader.config.agent.tool_timeout_seconds
+        except Exception as e:
+            logger.warning(
+                f"Failed to resolve tool timeout config: {e}, using default: 60s"
+            )
+            return 60
 
     def _resolve_execution_runtime(
         self,
@@ -451,13 +473,49 @@ class AgentLoop:
                         
                         if self.tools:
                             self.tools.set_tool_event_handler(tool_event_handler)
+                        tool_timeout = self._resolve_tool_timeout_seconds()
+                        # 自管闹钟的长任务工具（spawn / workflow_run /
+                        # external_coding_agent）内部已有有界等待与超时返回文案，
+                        # 主循环不叠加外层 wait_for，避免长任务被默认短超时误杀。
+                        uses_outer_timeout = tool_name not in self._SELF_ALARMING_TOOLS
                         try:
                             for attempt in range(self.max_retries):
                                 try:
-                                    result = await self.execute_tool(tool_name, tool_args)
+                                    if uses_outer_timeout:
+                                        result = await asyncio.wait_for(
+                                            self.execute_tool(tool_name, tool_args),
+                                            timeout=tool_timeout,
+                                        )
+                                    else:
+                                        result = await self.execute_tool(
+                                            tool_name, tool_args
+                                        )
                                     logger.debug(f"Tool {tool_name} succeeded")
                                     break
+                                except asyncio.TimeoutError:
+                                    # 挂死工具重试无意义：超时不重试，直接以模板文案
+                                    # 返回给模型（事实 + 下一步建议）。
+                                    result = (
+                                        f"Error: Tool '{tool_name}' timed out after "
+                                        f"{tool_timeout}s. Next: try a smaller scope "
+                                        f"or split the work."
+                                    )
+                                    logger.error(
+                                        f"Tool {tool_name} timed out after "
+                                        f"{tool_timeout}s"
+                                    )
+                                    break
+                                except RetryableToolError as e:
+                                    # 可重试（网络/超时/连接类）：计入重试次数
+                                    last_error = e
+                                    logger.warning(
+                                        f"Tool {tool_name} failed (attempt {attempt + 1}/{self.max_retries}): {e}"
+                                    )
+                                    if attempt < self.max_retries - 1:
+                                        await asyncio.sleep(self.retry_delay)
                                 except Exception as e:
+                                    # 兜底：防御 registry 意外上抛（正常契约下
+                                    # registry 会返回字符串，此处仅防异常路径）
                                     last_error = e
                                     logger.warning(
                                         f"Tool {tool_name} failed (attempt {attempt + 1}/{self.max_retries}): {e}"
@@ -539,7 +597,16 @@ class AgentLoop:
                                 f"status=success, duration_ms={duration_ms}"
                             )
                         else:
-                            error_msg = f"Tool execution failed after {self.max_retries} attempts: {str(last_error)}"
+                            if isinstance(last_error, RetryableToolError):
+                                # RetryableToolError.__str__ 不含 "Error:" 前缀，
+                                # 最终文案使用带前缀的模型可见模板
+                                error_msg = last_error.to_model_message()
+                            else:
+                                error_msg = (
+                                    f"Error: Tool execution failed after "
+                                    f"{self.max_retries} attempts: {str(last_error)}. "
+                                    f"Next: check the tool arguments and retry."
+                                )
                             logger.error(f"Tool {tool_name} failed permanently: {error_msg}")
                             
                             try:
@@ -751,9 +818,19 @@ class AgentLoop:
         logger.debug(f"执行工具: {tool_name}")
         
         try:
-            result = await self.tools.execute(tool_name, arguments, auto_record=False)
+            result = await self.tools.execute(
+                tool_name,
+                arguments,
+                auto_record=False,
+                # 主循环对可重试异常（网络/超时/连接类）opt-in 上抛，
+                # 以便外层 for attempt 重试循环真正生效。
+                raise_on_retryable=True,
+            )
             return result
             
+        except RetryableToolError:
+            # registry 已记录失败细节并审计落盘，这里透传供主循环重试
+            raise
         except Exception as e:
             logger.error(f"Tool execution failed: {tool_name} - {e}")
             raise

--- a/backend/modules/agent/subagent.py
+++ b/backend/modules/agent/subagent.py
@@ -574,6 +574,7 @@ class SubagentManager:
 
         except asyncio.CancelledError:
             task.status = TaskStatus.CANCELLED
+            task.error = "任务已被取消"
             task.completed_at = datetime.now()
             logger.info(f"Task {task.task_id} was cancelled")
             if handler:

--- a/backend/modules/config/schema.py
+++ b/backend/modules/config/schema.py
@@ -155,6 +155,16 @@ class SecurityConfig(BaseModel):
     restrict_to_workspace: bool = Field(default=False, description="是否限制命令在工作空间内执行")
 
 
+class AgentConfig(BaseModel):
+    """Agent 行为配置"""
+    tool_timeout_seconds: int = Field(
+        default=60,
+        ge=5,
+        le=1800,
+        description="主循环工具调用超时（秒）：超时后返回模板错误并提示模型拆分任务",
+    )
+
+
 class ChannelAccountConfig(BaseModel):
     """支持多机器人实例的基础渠道配置。"""
 
@@ -348,6 +358,7 @@ class AppConfig(BaseModel):
     model: ModelConfig = Field(default_factory=ModelConfig)
     workspace: WorkspaceConfig = Field(default_factory=WorkspaceConfig)
     security: SecurityConfig = Field(default_factory=SecurityConfig)
+    agent: AgentConfig = Field(default_factory=AgentConfig)
     channels: ChannelsConfig = Field(default_factory=ChannelsConfig)
     persona: PersonaConfig = Field(default_factory=PersonaConfig)
     mcp: McpConfig = Field(default_factory=McpConfig)

--- a/backend/modules/tools/_failure.py
+++ b/backend/modules/tools/_failure.py
@@ -1,0 +1,125 @@
+"""失败隔离协议模块（Failure Isolation Protocol）
+
+核心原则（源自 Armin Ronacher《Agent Design Is Still Hard》）：
+- 失败完整细节给人看（logger / 审计落盘）。
+- 失败一句话给模型看：``Error: <事实>. <原因>. Next: <下一步建议>.``
+
+本模块对外暴露三个符号：
+- ``format_failure``：把错误格式化为模型可见的一句话模板；
+- ``RetryableToolError``：可重试错误（网络/超时/5xx 类），由上层（主循环）捕获后重试；
+- ``is_retryable``：判断一个异常是否属于可重试类别。
+
+仅依赖标准库，避免引入循环依赖。
+"""
+
+from typing import Tuple
+
+_SENTENCE_ENDINGS: Tuple[str, ...] = (".", "!", "?", "。", "！", "？")
+
+
+def single_line(text: str, max_len: int = 300) -> str:
+    """把文本压成单行并截断，避免换行/超长破坏模型可见的一句话模板。"""
+    line = " ".join(str(text).split())
+    if len(line) > max_len:
+        line = line[:max_len] + "..."
+    return line
+
+
+def _ensure_sentence_ending(text: str) -> str:
+    """确保文本以句末标点结尾（避免拼接出 ``..``）。"""
+    text = text.rstrip()
+    if text and not text.endswith(_SENTENCE_ENDINGS):
+        return text + "."
+    return text
+
+
+def format_failure(
+    *,
+    kind: str,
+    summary: str,
+    next: str,
+    detail: str = "",
+) -> str:
+    """把错误格式化为模型可见的一句话模板。
+
+    模板：``Error: <一句话事实>. <原因>. Next: <下一步建议>.``
+
+    Args:
+        kind: 错误类别（execution_error / validation_error / permission_error ...），
+            仅供日志分类，不进入模型可见文案。
+        summary: 一句话事实（可含原因，例如 ``File not found: foo.py``，
+            若结尾已有句号则原样保留）。
+        next: 给模型的下一步建议；为空字符串时省略 ``Next:`` 段。
+        detail: 完整细节，仅供 logger / 审计使用，**不**进入返回值。
+
+    Returns:
+        str: 以 ``Error: `` 开头、可含 ``Next: `` 的模型可见文案。
+    """
+    parts = ["Error:", _ensure_sentence_ending(summary)]
+    if next:
+        parts.append("Next: " + _ensure_sentence_ending(str(next)))
+    return " ".join(parts)
+
+
+class RetryableToolError(Exception):
+    """可重试工具错误。
+
+    由 ``registry.execute`` 在 ``raise_on_retryable=True`` 时对网络/超时/5xx
+    类异常重新抛出，供主循环的 ``for attempt in range(max_retries)`` 捕获后重试。
+
+    ``__str__`` 返回**不含** ``Error:`` 前缀的模型可见单句（summary + Next），
+    避免主循环重试耗尽后的最终文案出现 ``Error: Error: ...`` 前缀重复。
+    """
+
+    def __init__(
+        self,
+        *,
+        tool_name: str,
+        summary: str,
+        next: str = "retry the operation",
+        detail: str = "",
+    ) -> None:
+        super().__init__(tool_name, summary)
+        self.tool_name = tool_name
+        self.summary = summary
+        self.next = next
+        self.detail = detail
+
+    def __str__(self) -> str:
+        parts = [_ensure_sentence_ending(self.summary)]
+        if self.next:
+            parts.append("Next: " + _ensure_sentence_ending(str(self.next)))
+        return " ".join(parts)
+
+    def to_model_message(self) -> str:
+        """返回模型可见完整文案（带 ``Error:`` 前缀）。"""
+        return format_failure(
+            kind="execution_error",
+            summary=self.summary,
+            next=self.next,
+            detail=self.detail,
+        )
+
+
+def _is_httpx_request_error(exc: BaseException) -> bool:
+    """判断是否为 httpx 网络请求异常（惰性 import，避免模块级硬依赖）。"""
+    try:
+        import httpx
+    except Exception:
+        return False
+    return isinstance(exc, httpx.RequestError)
+
+
+def is_retryable(exc: BaseException) -> bool:
+    """判断异常是否属于可重试类别（网络 / 超时 / 连接类）。
+
+    不可重试的典型错误：参数错误、权限错误、文件不存在等业务类失败——
+    重试不会改变结果，应直接以失败文案返回给模型。
+    """
+    if isinstance(exc, RetryableToolError):
+        return True
+    if isinstance(exc, (TimeoutError, ConnectionError)):
+        return True
+    if _is_httpx_request_error(exc):
+        return True
+    return False

--- a/backend/modules/tools/filesystem.py
+++ b/backend/modules/tools/filesystem.py
@@ -160,7 +160,10 @@ class ReadFileTool(Tool):
 
             file_path = self.validator.validate_path(path_str)
             if not file_path.exists():
-                return f"Error: File not found: {path_str}"
+                return (
+                    f"Error: File not found: {path_str}. "
+                    f"Next: run list_dir to see existing files."
+                )
             if not file_path.is_file():
                 return f"Error: Not a file: {path_str}"
 
@@ -228,7 +231,10 @@ class ReadFileTool(Tool):
                 file_path = self.validator.validate_path(path_str)
                 
                 if not file_path.exists():
-                    results.append(f"[File: {path_str}]\nError: File not found")
+                    results.append(
+                        f"[File: {path_str}]\nError: File not found. "
+                        f"Next: run list_dir to see existing files."
+                    )
                     error_count += 1
                     continue
                 
@@ -431,7 +437,10 @@ class EditFileTool(Tool):
         try:
             file_path = self.validator.validate_path(path_str)
             if not file_path.exists():
-                return f"Error: File not found: {path_str}"
+                return (
+                    f"Error: File not found: {path_str}. "
+                    f"Next: run list_dir to see existing files."
+                )
 
             content = file_path.read_text(encoding="utf-8")
 

--- a/backend/modules/tools/registry.py
+++ b/backend/modules/tools/registry.py
@@ -15,6 +15,12 @@ from backend.modules.tools.execution_context import (
     reset_tool_execution_context,
 )
 from backend.modules.tools.file_audit_logger import file_audit_logger
+from backend.modules.tools._failure import (
+    RetryableToolError,
+    format_failure,
+    is_retryable,
+    single_line,
+)
 
 # 使用 contextvars 实现异步安全的 session_id 存储
 # 每个异步任务都有独立的上下文，避免并发冲突
@@ -296,7 +302,13 @@ class ToolRegistry:
             logger.debug(f"Generated {len(self._definitions_cache)} tool definitions ({len(builtins)} builtin, {len(mcp_tools)} MCP)")
         return self._definitions_cache
 
-    async def execute(self, tool_name: str, arguments: Dict[str, Any], auto_record: bool = True) -> str:
+    async def execute(
+        self,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        auto_record: bool = True,
+        raise_on_retryable: bool = False,
+    ) -> str:
         """
         执行工具
         
@@ -304,12 +316,16 @@ class ToolRegistry:
             tool_name: 工具名称
             arguments: 工具参数
             auto_record: 是否自动记录到工具对话历史（默认 True）
+            raise_on_retryable: 是否把可重试异常（网络/超时/连接类）以
+                RetryableToolError 重新抛出供上层重试（仅主循环 opt-in，默认
+                False 保持"不抛异常、返回字符串"契约）
             
         Returns:
             str: 工具执行结果（包括错误信息）
             
         Note:
-            此方法不会抛出异常，而是返回错误字符串
+            此方法默认不会抛出异常，而是返回错误字符串；仅当
+            raise_on_retryable=True 时，可重试异常会以 RetryableToolError 抛出。
         """
         tool = self.get_tool(tool_name)
         
@@ -437,16 +453,44 @@ class ToolRegistry:
             return result
             
         except Exception as e:
-            error_msg = f"Error executing {tool_name}: {str(e)}"
-            logger.error(error_msg)
-            
-            # 计算执行时间
+            # 失败隔离：失败细节给日志/审计（str(e) 全量），一句话模板给模型。
             duration_ms = int((datetime.now() - start_time).total_seconds() * 1000)
-            
+
+            # 可重试（网络/超时/连接类）：仅当调用方显式 opt-in 时以
+            # RetryableToolError 上抛，供上层（主循环）捕获后重试。
+            if raise_on_retryable and is_retryable(e):
+                retryable_error = RetryableToolError(
+                    tool_name=tool_name,
+                    summary=f"Tool '{tool_name}' failed ({type(e).__name__}): "
+                    f"{single_line(e)}",
+                    next="retry the operation",
+                    detail=str(e),
+                )
+                logger.error(
+                    f"Tool '{tool_name}' failed with retryable error "
+                    f"({type(e).__name__}): {e}"
+                )
+                # 审计落盘完整细节后上抛；不写入对话历史——本次失败将被重试覆盖，
+                # 重试耗尽后的最终错误由主循环统一记录。
+                if self._audit_enabled:
+                    file_audit_logger.update_result(
+                        call_id, str(e), "error", error=str(e), duration_ms=duration_ms
+                    )
+                raise retryable_error from e
+
+            # 不可重试（参数/权限/文件类）或未 opt-in：以模板文案返回给模型。
+            error_msg = format_failure(
+                kind="execution_error",
+                summary=f"Tool '{tool_name}' failed: {single_line(e)}",
+                next="check the tool arguments and retry",
+                detail=str(e),
+            )
+            logger.error(f"Tool '{tool_name}' failed: {e}")
+
             # 更新审计日志
             if self._audit_enabled:
                 file_audit_logger.update_result(call_id, str(e), "error", error=str(e), duration_ms=duration_ms)
-            
+
             # 记录到工具对话历史（失败）
             if auto_record and self._session_id:
                 try:
@@ -461,7 +505,7 @@ class ToolRegistry:
                     )
                 except Exception as conv_err:
                     logger.warning(f"Failed to record tool conversation: {conv_err}")
-            
+
             return error_msg
 
     def get_stats(self) -> Dict[str, Any]:

--- a/backend/modules/tools/screenshot.py
+++ b/backend/modules/tools/screenshot.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Literal
 from loguru import logger
 
 from backend.modules.tools.base import Tool
+from backend.modules.tools._failure import format_failure, single_line
 
 
 class ScreenshotTool(Tool):
@@ -215,8 +216,14 @@ class ScreenshotTool(Tool):
                 )
                 
         except Exception as e:
-            logger.error(f"桌面截图失败: {e}")
-            return f"Error capturing desktop screenshot: {str(e)}"
+            detail = f"桌面截图失败: {e}"
+            logger.error(detail)
+            return format_failure(
+                kind="execution_error",
+                summary=f"Failed to capture desktop screenshot: {single_line(e)}",
+                next="check the screen/monitor is available, then retry",
+                detail=detail,
+            )
 
     async def _capture_webpage(self, **kwargs: Any) -> str:
         """
@@ -315,5 +322,11 @@ class ScreenshotTool(Tool):
                 )
                 
         except Exception as e:
-            logger.error(f"网页截图失败: {e}")
-            return f"Error capturing webpage screenshot: {str(e)}"
+            detail = f"网页截图失败: {e}"
+            logger.error(detail)
+            return format_failure(
+                kind="execution_error",
+                summary=f"Failed to capture webpage screenshot: {single_line(e)}",
+                next="verify the URL is reachable and playwright browsers are installed, then retry",
+                detail=detail,
+            )

--- a/backend/modules/tools/send_media.py
+++ b/backend/modules/tools/send_media.py
@@ -7,6 +7,7 @@ from typing import Any, List, Optional, Tuple
 from loguru import logger
 
 from backend.modules.tools.base import Tool
+from backend.modules.tools._failure import format_failure, single_line
 
 
 IMAGE_EXTENSIONS = {'.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'}
@@ -291,8 +292,14 @@ class SendMediaTool(Tool):
             return result_msg
             
         except Exception as e:
-            logger.error(f"发送文件失败: {e}")
-            return f"发送文件失败: {str(e)}"
+            detail = f"发送文件失败: {e}"
+            logger.error(detail)
+            return format_failure(
+                kind="execution_error",
+                summary=f"发送文件失败: {single_line(e)}",
+                next="check the file paths are valid, then retry",
+                detail=detail,
+            )
 
     def _queue_wecom_longconn_media(
         self,

--- a/backend/modules/tools/shell.py
+++ b/backend/modules/tools/shell.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional
 from loguru import logger
 
 from backend.modules.tools.base import Tool
+from backend.modules.tools._failure import format_failure, single_line
 from backend.modules.tools.monitoring import (
     MONITOR_PARAMETER_SCHEMA,
     build_default_monitor_config,
@@ -483,8 +484,14 @@ class ExecTool(Tool):
             return result
             
         except Exception as e:
-            logger.error(f"执行命令时发生异常: {e}")
-            return f"Error executing command: {str(e)}"
+            detail = f"执行命令时发生异常: {e}"
+            logger.error(detail)
+            return format_failure(
+                kind="execution_error",
+                summary=f"Command execution failed: {single_line(e)}",
+                next="check the command and environment, then retry",
+                detail=detail,
+            )
 
     def _decode_output(self, output: bytes) -> str:
         """解码命令输出，自动检测字符编码
@@ -576,7 +583,12 @@ class ExecTool(Tool):
                         f"(invalid denylist regex: {error})"
                     )
                 if matched:
-                    return "Error: Command blocked by safety guard (dangerous pattern detected)"
+                    return (
+                        "Error: Command blocked by safety guard "
+                        "(dangerous pattern detected). "
+                        "Next: rewrite the command without destructive operations "
+                        "(e.g. rm -rf) and retry."
+                    )
         
         # 工作空间路径限制
         if self.restrict_to_workspace:
@@ -622,7 +634,12 @@ class ExecTool(Tool):
                     try:
                         p.relative_to(self.workspace)
                     except ValueError:
-                        return f"Error: Command blocked by safety guard (path outside working dir: {raw})"
+                        return (
+                            f"Error: Command blocked by safety guard "
+                            f"(path outside working dir: {raw}). "
+                            f"Next: rewrite the command to use a path inside the "
+                            f"working directory and retry."
+                        )
         
         return None
 

--- a/backend/modules/tools/spawn.py
+++ b/backend/modules/tools/spawn.py
@@ -154,6 +154,12 @@ class SpawnTool(Tool):
         except asyncio.TimeoutError:
             return f"子 Agent [{display_label}] 超时 (ID: {task_id})，任务仍在后台运行。"
 
+        from backend.modules.agent.subagent import TaskStatus
+
+        # 取消 ≠ 失败 ≠ 完成：先判取消，避免"任务已被取消"被误报为"已完成"
+        if sub_task.status == TaskStatus.CANCELLED:
+            return f"子 Agent [{display_label}] 已取消 (ID: {task_id})。"
+
         if sub_task.error:
             return f"子 Agent [{display_label}] 失败 (ID: {task_id}): {sub_task.error}"
 

--- a/backend/modules/tools/web.py
+++ b/backend/modules/tools/web.py
@@ -11,6 +11,7 @@ import httpx
 from loguru import logger
 
 from backend.modules.tools.base import Tool
+from backend.modules.tools._failure import format_failure, single_line
 
 # 尝试导入可选依赖
 try:
@@ -268,8 +269,16 @@ class WebFetchTool(Tool):
                 return json.dumps(result, ensure_ascii=False)
             
         except Exception as e:
-            logger.error(f"Web fetch error for {url}: {e}")
-            return json.dumps({"error": str(e), "url": url})
+            detail = f"Web fetch error for {url}: {e}"
+            logger.error(detail)
+            error_message = format_failure(
+                kind="execution_error",
+                summary=f"Failed to fetch URL: {single_line(e)}",
+                next="verify the URL is reachable and network is available, then retry",
+                detail=detail,
+            )
+            # 保持 JSON 结构（输出格式 json 的调用方依赖），error 字段升级为模板文案
+            return json.dumps({"error": error_message, "url": url})
     
     async def _fetch_with_scrapling(self, url: str, mode: str, max_chars: int, output_format: str) -> dict:
         """使用 Scrapling 获取内容"""

--- a/backend/modules/wiki/tool.py
+++ b/backend/modules/wiki/tool.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from loguru import logger
 
 from backend.modules.tools.base import Tool
+from backend.modules.tools._failure import format_failure, single_line
 from .service import WikiService
 
 
@@ -144,8 +145,14 @@ class WikiTool(Tool):
             else:
                 return f"Unknown action: {action}. Available: search, ask, get, batch_get, list, stats, create, update, delete, sync"
         except Exception as e:
-            logger.error(f"Wiki {action} failed: {e}")
-            return f"Wiki {action} failed: {e}"
+            detail = f"Wiki {action} failed: {e}"
+            logger.error(detail)
+            return format_failure(
+                kind="execution_error",
+                summary=f"Wiki {action} failed: {single_line(e)}",
+                next="check the wiki entry and arguments, then retry",
+                detail=detail,
+            )
 
     def _handle_search(self, query: Optional[str], top_k: int) -> str:
         """处理搜索请求（优化版：使用search_with_metadata减少文件读取）"""


### PR DESCRIPTION
### 背景
对应 Issue #117（工具层失败处理 3 处机制性缺陷：主循环无超时、子 agent 取消误报完成、重试死代码）。

### 改动
- **主循环工具超时**：`agent/loop.py` 在 `execute_tool` 外层加 `asyncio.wait_for` 闹钟，超时秒数走新增配置 `agent.tool_timeout_seconds`（默认 60s，范围 5-1800）；`TimeoutError` 不重试、直接返回模板文案；`RetryableToolError` 计入重试；spawn / workflow_run / external_coding_agent 等自管长任务工具豁免外层 `wait_for`（内部已有界，不会被误杀）。
- **取消状态修正**：`agent/subagent.py` 的 `CancelledError` 分支补设 `task.error`；`tools/spawn.py` 显式判 `TaskStatus.CANCELLED`，返回“已取消”而非“已完成”。
- **重试真正生效**：`tools/registry.py` 新增 `raise_on_retryable` 可选参（默认 False，保持既有“不抛异常、返回字符串”契约，其余 7 处调用方无回归）；兜底 except 按 `is_retryable` 分流——网络 / 超时 / 5xx 上抛 `RetryableToolError` 让主循环重试循环真正可跑；上抛前审计落盘收尾。
- **统一失败文案**：新增 `tools/_failure.py`（`format_failure` / `RetryableToolError` / `is_retryable`），模板 `Error: <事实>. <原因>. Next: <建议>.`；wiki / web / screenshot / send_media / registry 失败文案统一走模板，原始堆栈只落 logger / 审计；filesystem / shell 拦截文案补 `Next:` 建议。

### 验证
- `py_compile` 全量通过；`tests/` 相关单测通过（含 P1 `test_prompt_cache_stability.py` 无影响）
- mock 注入“前两次失败、第三次成功”验证重试真实跑满；取消子 agent 返回含“已取消”；hang 工具超时后返回模板文案且不卡死对话
- 飞书 / Web / CLI 三渠道正常调用返回不变，失败场景文案统一升级

Fixes #117