### PR TITLE
[Fix] 新增 LLMProvider.chat_completion 基类方法：修复生产环境 CRAG 纠偏与 LLM 生成静默失效

### DIFF
--- a/backend/modules/providers/base.py
+++ b/backend/modules/providers/base.py
@@ -80,6 +80,29 @@ class LLMProvider(ABC):
         """流式聊天补全"""
         pass
 
+    async def chat_completion(
+        self,
+        prompt: str,
+        max_tokens: int = 2000,
+        temperature: float = 0.3,
+    ) -> str:
+        """非流式便捷方法：包装 chat_stream，累积完整回答。
+
+        Wiki 检索链路（grader / 查询改写 / 块级生成）等单轮调用使用此方法。
+        prompt 会被包成单条 user 消息；流中出现的错误块（StreamChunk.error）
+        以 RuntimeError 抛出，由调用方的降级逻辑兜底。
+        """
+        messages = [{"role": "user", "content": prompt}]
+        parts: List[str] = []
+        async for chunk in self.chat_stream(
+            messages, max_tokens=max_tokens, temperature=temperature
+        ):
+            if chunk.is_error:
+                raise RuntimeError(chunk.error)
+            if chunk.content is not None:
+                parts.append(chunk.content)
+        return "".join(parts)
+
     @abstractmethod
     def get_default_model(self) -> str:
         """获取默认模型"""

--- a/tests/rag/test_provider_completion.py
+++ b/tests/rag/test_provider_completion.py
@@ -1,0 +1,187 @@
+"""Phase 0 回归测试：LLMProvider.chat_completion（P0 API 断裂修复）
+
+背景：Wiki 链路的 6 处调用点（tool.py 232/336/378/417、api/wiki.py 338/729）
+调用了 provider.chat_completion，但基类从未定义该方法——生产环境抛
+AttributeError 后被调用方 except Exception 吞掉，CRAG 纠偏与 LLM 生成
+静默退化为块列表输出。本文件验证基类便捷方法包裹 chat_stream 的行为：
+
+1. 多个内容块按序拼接；
+2. 错误块（StreamChunk.error）以 RuntimeError 抛出；
+3. 空流返回空串；
+4. prompt 正确包成单条 user 消息，max_tokens / temperature 透传；
+5. 非 content 块（usage / finish / reasoning / tool_call）不混入结果。
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.modules.providers.base import LLMProvider, StreamChunk
+
+
+class FakeStreamProvider(LLMProvider):
+    """只实现 chat_stream（不自带 chat_completion），
+    用于证明所有真实 Provider 均经基类继承获得该方法。"""
+
+    def __init__(self, chunks=None):
+        super().__init__()
+        self.chunks = list(chunks or [])
+        self.calls = []
+
+    async def chat_stream(
+        self,
+        messages,
+        tools=None,
+        model=None,
+        max_tokens=4096,
+        temperature=0.0,
+        **kwargs,
+    ):
+        self.calls.append(
+            {
+                "messages": messages,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            }
+        )
+        for c in self.chunks:
+            yield c
+
+    def get_default_model(self):
+        return "fake-model"
+
+
+class TestChatCompletion:
+    def test_concatenates_content_chunks_in_order(self):
+        provider = FakeStreamProvider(
+            [
+                StreamChunk(content="检索质量"),
+                StreamChunk(content="评估："),
+                StreamChunk(content="all"),
+            ]
+        )
+        out = asyncio.run(provider.chat_completion("评估检索质量"))
+        assert out == "检索质量评估：all"
+
+    def test_error_chunk_raises_runtime_error(self):
+        provider = FakeStreamProvider(
+            [
+                StreamChunk(content="部分内容"),
+                StreamChunk(error="rate limited"),
+            ]
+        )
+        with pytest.raises(RuntimeError, match="rate limited"):
+            asyncio.run(provider.chat_completion("任意问题"))
+
+    def test_empty_stream_returns_empty_string(self):
+        provider = FakeStreamProvider([])
+        assert asyncio.run(provider.chat_completion("任意问题")) == ""
+
+    def test_wraps_prompt_and_passes_params(self):
+        provider = FakeStreamProvider([StreamChunk(content="ok")])
+        out = asyncio.run(
+            provider.chat_completion("写一句部署说明", max_tokens=3000, temperature=0.7)
+        )
+        assert out == "ok"
+        assert len(provider.calls) == 1
+        call = provider.calls[0]
+        assert call["messages"] == [{"role": "user", "content": "写一句部署说明"}]
+        assert call["max_tokens"] == 3000
+        assert call["temperature"] == 0.7
+
+    def test_default_params(self):
+        provider = FakeStreamProvider([StreamChunk(content="ok")])
+        asyncio.run(provider.chat_completion("任意问题"))
+        call = provider.calls[0]
+        assert call["max_tokens"] == 2000
+        assert call["temperature"] == 0.3
+
+    def test_skips_non_content_chunks(self):
+        """usage / finish_reason / reasoning / tool_call 块均无 content，不得混入"""
+        provider = FakeStreamProvider(
+            [
+                StreamChunk(reasoning_content="内心独白"),
+                StreamChunk(content="答案"),
+                StreamChunk(usage={"total_tokens": 42}),
+                StreamChunk(finish_reason="stop"),
+            ]
+        )
+        out = asyncio.run(provider.chat_completion("任意问题"))
+        assert out == "答案"
+
+
+class ScriptedStreamProvider(LLMProvider):
+    """按调用顺序返回预设回复的流式 provider。
+
+    与 test_tool_switch.ScriptedProvider 的关键差异：本类**不自带**
+    chat_completion，完全依赖基类便捷方法——即真实生产 provider 的形态。
+    """
+
+    def __init__(self, replies):
+        super().__init__()
+        self.replies = list(replies)
+        self.calls = []
+
+    async def chat_stream(self, messages, tools=None, model=None,
+                          max_tokens=4096, temperature=0.0, **kwargs):
+        prompt = messages[0]["content"]
+        self.calls.append(prompt)
+        if not self.replies:
+            yield StreamChunk(content="DEFAULT")
+            return
+        reply = self.replies.pop(0)
+        if isinstance(reply, Exception):
+            yield StreamChunk(error=str(reply))
+            return
+        # 拆成两个块返回，同时验证流式拼接
+        mid = max(1, len(reply) // 2)
+        yield StreamChunk(content=reply[:mid])
+        yield StreamChunk(content=reply[mid:])
+
+    def get_default_model(self):
+        return "fake-model"
+
+
+class TestProductionWiring:
+    """P0 修复的生产链路证明：WikiTool._rag_ask 经基类 chat_completion 走通 grader → 生成。
+
+    修复前，这类 provider 会在 6 处调用点抛 AttributeError 并被吞掉，
+    ask 恒回退到块列表输出（matching sections）。
+    """
+
+    def test_rag_ask_grades_and_generates_via_base_method(
+        self, tmp_path, monkeypatch
+    ):
+        import frontmatter
+        import types
+
+        concepts = tmp_path / "concepts"
+        concepts.mkdir(parents=True)
+        post = frontmatter.Post("使用 docker-compose 一键启动，命令为 docker compose up -d。\n")
+        post.metadata["title"] = "部署指南"
+        post.metadata["tags"] = ["ops"]
+        (concepts / "deploy.md").write_text(frontmatter.dumps(post), encoding="utf-8")
+
+        provider = ScriptedStreamProvider([
+            '{"grade": "all", "relevant": [1, 2]}',  # grader
+            "ANSWER_OK",                              # 生成
+        ])
+        fake_app = types.ModuleType("backend.app")
+        fake_app.get_shared_provider = lambda: provider
+        monkeypatch.setitem(sys.modules, "backend.app", fake_app)
+        monkeypatch.setenv("COUNTBOT_RAG_CHUNKS", "1")
+
+        from backend.modules.wiki.tool import WikiTool
+
+        tool = WikiTool(tmp_path)
+        out = asyncio.run(tool._handle_ask("如何用 Docker 部署"))
+
+        assert out == "ANSWER_OK"  # LLM 生成，而非块列表回退
+        assert "matching sections" not in out
+        assert len(provider.calls) == 2  # 评估 1 次 + 生成 1 次
+        assert "检索质量评估器" in provider.calls[0]
+        assert "docker-compose" in provider.calls[1]


### PR DESCRIPTION
Fixes #119

## 问题

6 处调用 `provider.chat_completion(...)`（`wiki/tool.py:232/336/378/417`、`api/wiki.py:338/729`），但该方法在 `LLMProvider` 基类与两个真实 Provider 上从未定义。生产环境抛 `AttributeError` 被 `except Exception` 吞掉，**CRAG 评估路由与 LLM 生成在生产环境整体 no-op**（#115 的评测数字来自注入 `SimpleProvider` 的离线环境）。

## 修复

`backend/modules/providers/base.py` 新增非抽象便捷方法：

```python
async def chat_completion(self, prompt: str,
                          max_tokens: int = 2000,
                          temperature: float = 0.3) -> str
```

- prompt 包成单条 user 消息，包装 `chat_stream` 累积 content 块
- 错误块抛 `RuntimeError`，由调用方既有降级逻辑兜底
- 不触碰流式路径；`OpenAIProvider` / `AnthropicProvider` 经继承自动获得

## 验证

| 门禁 | 结果 |
|---|---|
| 全量测试 | **145 passed**（138 既有 + 7 新增，零劣化）|
| 真实模型 60 题评测（deepseek-v4-flash） | `llm_calls=133 > 60`，答案为自然语言而非块列表回退 → grader/生成链路真实运转 |

新增测试 `tests/rag/test_provider_completion.py`（7 用例）：流式拼接 / 错误传播 / 空流 / prompt 包装与参数透传 / 默认参数 / 非 content 块过滤 / **生产链路集成**（仅实现 `chat_stream` 的 provider 接入 `WikiTool._handle_ask`，证明 grader→生成走通）。

## 附带情报（供后续优化参考）

真实模型基线与 #115 离线数字差距显著：负样本拒答 8/10（离线 10/10）、正样本 40/50（离线 46/50）、引用率 68%（离线 72%）——印证了「离线评测不代表生产行为」的判断，这组数据可作为后续检索增强（混合检索 / rerank）的真实对照基线。